### PR TITLE
[codex] Fix mobile layout overflows

### DIFF
--- a/app/brain/page.tsx
+++ b/app/brain/page.tsx
@@ -24,10 +24,10 @@ export default function BrainPage() {
 
   return (
     <main className="site-container">
-      <section className="py-20 sm:py-24">
-        <div className="section-kicker mb-8">Second Brain</div>
-        <h1 className="display-heading text-[clamp(4rem,12vw,8.5rem)]">Brain</h1>
-        <p className="mt-10 max-w-3xl text-[15px] leading-[1.75] text-muted-foreground">
+      <section className="py-14 sm:py-20 md:py-24">
+        <div className="section-kicker mb-6 sm:mb-8">Second Brain</div>
+        <h1 className="display-heading text-[clamp(3.25rem,18vw,8.5rem)]">Brain</h1>
+        <p className="mt-7 max-w-3xl text-[15px] leading-[1.75] text-muted-foreground sm:mt-10">
           A working collection of raw notes, linked insights, source summaries, diagrams, tables,
           and post seeds before they become polished writing.
         </p>

--- a/app/globals.css
+++ b/app/globals.css
@@ -168,6 +168,7 @@
 
   html {
     background: var(--background);
+    overflow-x: clip;
   }
 
   body {
@@ -176,6 +177,7 @@
       var(--font-mono), ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono',
       'Courier New', monospace;
     min-height: 100vh;
+    overflow-x: clip;
   }
 
   ::selection {
@@ -185,6 +187,16 @@
 
   a {
     text-underline-offset: 4px;
+  }
+
+  main a {
+    overflow-wrap: anywhere;
+  }
+
+  main a.inline-flex {
+    max-width: 100%;
+    min-width: 0;
+    flex-wrap: wrap;
   }
 
   button,
@@ -251,6 +263,7 @@
   letter-spacing: 0.005em;
   text-transform: uppercase;
   color: var(--primary);
+  overflow-wrap: anywhere;
 }
 
 .section-kicker {
@@ -384,6 +397,10 @@
   font-family: var(--font-mono), ui-monospace, monospace;
 }
 
+.presentation-stage {
+  min-width: 0;
+}
+
 .presentation-slide-surface h1,
 .presentation-slide-surface h2 {
   font-family: var(--font-serif), Georgia, serif !important;
@@ -482,4 +499,26 @@
 
 .presentation-slide-surface [style*='box-shadow'] {
   box-shadow: none !important;
+}
+
+@media (max-width: 639px) {
+  .site-container,
+  .site-container-narrow {
+    width: min(100% - 24px, 1280px);
+  }
+
+  .display-heading {
+    line-height: 1.04;
+  }
+
+  [data-slot='card-content'],
+  [data-slot='card-header'],
+  [data-slot='card-footer'] {
+    padding-inline: 1.25rem;
+  }
+
+  [data-slot='card-content'].p-8,
+  [data-slot='card-content'].md\:p-10 {
+    padding: 1.25rem;
+  }
 }

--- a/app/presentations/page.tsx
+++ b/app/presentations/page.tsx
@@ -60,10 +60,10 @@ const presentations: PresentationEntry[] = [
 export default function PresentationsPage() {
   return (
     <main className="site-container">
-      <section className="py-20 sm:py-24">
-        <div className="section-kicker mb-8">Slides & Talks</div>
-        <h1 className="display-heading text-[clamp(4rem,12vw,8.5rem)]">Presentations</h1>
-        <p className="mt-10 max-w-3xl text-[15px] leading-[1.75] text-muted-foreground">
+      <section className="py-14 sm:py-20 md:py-24">
+        <div className="section-kicker mb-6 sm:mb-8">Slides & Talks</div>
+        <h1 className="display-heading text-[clamp(1.75rem,8.75vw,8.5rem)]">Presentations</h1>
+        <p className="mt-7 max-w-3xl text-[15px] leading-[1.75] text-muted-foreground sm:mt-10">
           Decks and talks on AI agents, data, and building. Mostly the same arguments as the blog,
           with more diagrams and worse jokes.
         </p>
@@ -73,13 +73,13 @@ export default function PresentationsPage() {
         {presentations.map((presentation) => (
           <article
             key={presentation.href}
-            className="flex min-h-[280px] flex-col border border-dashed border-border p-7"
+            className="flex min-h-[260px] min-w-0 flex-col border border-dashed border-border p-5 sm:min-h-[280px] sm:p-7"
           >
-            <div className="flex justify-between gap-5 text-xs uppercase tracking-[0.12em] text-muted-foreground">
+            <div className="flex flex-wrap justify-between gap-3 text-xs uppercase tracking-[0.12em] text-muted-foreground">
               <span>{presentation.date}</span>
               <span>{presentation.kind}</span>
             </div>
-            <h2 className="display-heading mt-8 text-[clamp(1.55rem,3vw,2rem)] leading-[1.12]">
+            <h2 className="display-heading mt-7 text-[clamp(1.45rem,8vw,2rem)] leading-[1.12] sm:mt-8">
               {presentation.title}
             </h2>
             <p className="mt-6 text-[13.5px] leading-[1.65] text-foreground">
@@ -102,7 +102,7 @@ export default function PresentationsPage() {
           </article>
         ))}
 
-        <div className="flex min-h-[280px] flex-col items-center justify-center border border-dashed border-[var(--hair)] p-7 text-center">
+        <div className="flex min-h-[260px] flex-col items-center justify-center border border-dashed border-[var(--hair)] p-5 text-center sm:min-h-[280px] sm:p-7">
           <div className="font-serif text-lg italic text-muted-foreground">
             your next talk here...
           </div>

--- a/components/blog-card.tsx
+++ b/components/blog-card.tsx
@@ -9,10 +9,10 @@ export function BlogCard({ post }: BlogCardProps) {
   return (
     <Link
       href={`/blog/${post.slug}`}
-      className="group flex min-h-[290px] flex-col border border-dashed border-border p-6 text-foreground no-underline transition-colors hover:bg-[var(--hover)] sm:p-7"
+      className="group flex min-h-[260px] min-w-0 flex-col border border-dashed border-border p-5 text-foreground no-underline transition-colors hover:bg-[var(--hover)] sm:min-h-[290px] sm:p-7"
     >
-      <div className="flex items-start justify-between gap-5">
-        <h2 className="display-heading max-w-[82%] text-[clamp(1.35rem,2.5vw,1.8rem)] leading-[1.12] transition-colors group-hover:text-foreground">
+      <div className="flex min-w-0 flex-wrap items-start justify-between gap-3 sm:gap-5">
+        <h2 className="display-heading min-w-0 flex-1 text-[clamp(1.35rem,8vw,1.8rem)] leading-[1.12] transition-colors group-hover:text-foreground">
           {post.title}
         </h2>
         {post.audioUrl && (
@@ -24,7 +24,7 @@ export function BlogCard({ post }: BlogCardProps) {
 
       <p className="mt-auto pt-7 text-[13px] leading-[1.65] text-foreground">{post.description}</p>
 
-      <div className="mt-5 flex justify-between gap-4 text-[11px] uppercase tracking-[0.04em] text-muted-foreground">
+      <div className="mt-5 flex flex-wrap justify-between gap-3 text-[11px] uppercase tracking-[0.04em] text-muted-foreground">
         <time dateTime={post.publishedAt}>
           {new Date(post.publishedAt).toLocaleDateString('en-US', {
             month: 'short',

--- a/components/presentations/shared/presentation-layout.tsx
+++ b/components/presentations/shared/presentation-layout.tsx
@@ -77,7 +77,7 @@ function SectionMarker({ section }: { section?: string }) {
   if (loopIndex < 0) return null;
 
   return (
-    <div className="fixed left-8 top-7 z-50 font-mono">
+    <div className="fixed top-5 left-4 z-50 hidden font-mono sm:block lg:left-8 lg:top-7">
       <div className="text-[10px] uppercase tracking-[0.24em] text-muted-foreground">
         Agentic loop
       </div>
@@ -115,7 +115,7 @@ export function PresentationLayout({
   const currentSlide = slides[currentIndex];
 
   return (
-    <div className="presentation-slide-surface fixed inset-0 z-50 overflow-hidden">
+    <div className="presentation-slide-surface fixed inset-0 z-50 overflow-auto md:overflow-hidden">
       <div className="fixed top-0 left-0 right-0 z-50 h-[3px] bg-[var(--hair)]">
         <div
           className="h-full bg-primary transition-all duration-300 ease-out"
@@ -127,8 +127,8 @@ export function PresentationLayout({
 
       <SectionMarker section={currentSlide?.section} />
 
-      <div className="h-full flex">
-        <div className="flex-1 h-full">
+      <div className="flex h-full min-w-0">
+        <div className="h-full min-w-0 flex-1">
           <SlideStepProvider
             key={currentSlug}
             pathname={pathname}
@@ -142,7 +142,7 @@ export function PresentationLayout({
                 animate={{ opacity: 1 }}
                 exit={{ opacity: 0 }}
                 transition={{ duration: 0.2 }}
-                className="flex h-full w-full items-center justify-center"
+                className="presentation-stage flex h-full w-full min-w-0 items-center justify-center"
               >
                 {children}
               </motion.div>
@@ -153,7 +153,7 @@ export function PresentationLayout({
         {sidebar}
       </div>
 
-      <div className="fixed right-6 bottom-4 z-50 font-mono text-sm text-muted-foreground">
+      <div className="fixed right-3 bottom-3 z-50 font-mono text-xs text-muted-foreground sm:right-6 sm:bottom-4 sm:text-sm">
         {currentIndex + 1} / {slides.length}
       </div>
     </div>

--- a/components/presentations/voice-agents/jarvis/jarvis-sidebar.tsx
+++ b/components/presentations/voice-agents/jarvis/jarvis-sidebar.tsx
@@ -121,7 +121,7 @@ export function JarvisSidebar() {
   }, [messages]);
 
   return (
-    <div className="w-80 shrink-0 bg-background/95 backdrop-blur border-l border-primary/20 flex flex-col h-full">
+    <div className="hidden h-full w-80 shrink-0 flex-col border-l border-primary/20 bg-background/95 backdrop-blur lg:flex">
       {/* Header */}
       <div className="p-4 border-b border-primary/20 flex items-center justify-between">
         <div className="flex items-center gap-2">


### PR DESCRIPTION
Fixes mobile overflow and cramped spacing across the presentations index, brain page, blog cards, and shared presentation slide chrome. The root issue was a mix of large minimum heading sizes, fixed-width presentation controls, and non-wrapping inline content that could push narrow viewports wider than the screen. The PR adds mobile-safe wrapping, narrower container/card spacing, and hides the Jarvis sidebar below desktop widths. Validated with `pnpm lint`, `pnpm typecheck`, `pnpm build`, and Playwright mobile overflow checks at 375px and 320px.