### PR TITLE
[codex] Add speech synthesis research insights

### DIFF
--- a/brain/inbox/dr/chatterbox/01-primary-source-summary.md
+++ b/brain/inbox/dr/chatterbox/01-primary-source-summary.md
@@ -1,0 +1,481 @@
+---
+title: "Primary-source summary of Resemble AI Chatterbox TTS internals from official GitHub and Hugging Face model cards only: T3, S3Tokenizer, S3Gen, Turbo, voice conversion, watermarking, disclosed training and benchmark claims."
+generated_at: 2026-07-02T11:53:14.821755+00:00
+strategy: deep-agent-v1
+effort: standard
+planner_model: "z-ai/glm-5.2"
+worker_model: "deepseek/deepseek-v4-flash"
+writer_model: "z-ai/glm-5.2"
+---
+
+# Chatterbox TTS: Architecture, Components, Capabilities, and Disclosed Benchmarks from Official Sources
+
+## Abstract
+
+Chatterbox is an open-source text-to-speech (TTS) model family developed by Resemble AI. Official GitHub and Hugging Face sources disclose a modular pipeline built around four core components: T3 (a Token-to-Token Transformer), S3Tokenizer (a speech tokenizer), S3Gen (a diffusion-based waveform decoder), and a VoiceEncoder, with PerTh watermarking applied to every generation. This report synthesizes primary-source documentation to explain how these components connect, how the Turbo variant reduces generation cost via distillation, what voice conversion and watermarking mechanisms are disclosed, and what training and benchmark claims are officially supported. Where official sources are silent, the report states the absence explicitly.
+
+## Research Question
+
+What does official Resemble AI documentation (GitHub repository, Hugging Face model cards, and official product pages) disclose about the internal architecture, component design, Turbo mode, voice conversion, watermarking, training data, and benchmark claims of Chatterbox TTS?
+
+## Method
+
+Evidence was drawn exclusively from the admitted source register, comprising the official GitHub repository (`resemble-ai/chatterbox`), Hugging Face model cards and file listings (`ResembleAI/chatterbox`, `ResembleAI/chatterbox-turbo`, `ResembleAI/chatterbox-turbo-ONNX`), NVIDIA Build model card, and official Resemble AI product pages. Source code files (`tts.py`, `s3tokenizer.py`) were treated as primary technical evidence. Marketing language was distinguished from technical disclosure. No third-party evaluations, blog posts, or independent audits were included.
+
+## Conceptual Background
+
+Chatterbox belongs to the class of neural TTS systems that separate linguistic modeling from acoustic synthesis. The pipeline converts input text into discrete linguistic representations, autoregressively generates discrete speech tokens, and then decodes those tokens into waveforms. Key terms of art used across official sources are defined below.
+
+| Term | Definition (as used in official sources) |
+|---|---|
+| T3 | Token-to-Token Transformer; text-to-speech-token generator based on a Llama-style backbone [S8, S12, S18] |
+| S3Tokenizer | Speech tokenizer that converts audio into discrete speech tokens via log-mel quantization [S17] |
+| S3Gen | Diffusion-based decoder with flow matching that converts speech tokens to mel spectrograms and then waveforms [S12, S18] |
+| VoiceEncoder | Component that produces speaker embeddings from reference audio [S18] |
+| EnTokenizer | Text tokenizer for English input [S18] |
+| PerTh | Perceptual Threshold deep neural watermarker using psychoacoustic masking [S4, S26] |
+| Flow matching | A continuous normalizing flow method used in S3Gen for mel generation [S12] |
+| Zero-shot voice cloning | Voice identity transfer from a short reference clip without fine-tuning [S7, S26] |
+
+## Findings
+
+### Overall Architecture
+
+The `ChatterboxTTS` class instantiates four sub-components: `T3`, `S3Gen`, `VoiceEncoder`, and `EnTokenizer`, and attaches a `perth.PerthImplicitWatermarker` instance [S18, S36]. The pipeline operates as follows: text is tokenized by `EnTokenizer`; the `VoiceEncoder` extracts a speaker embedding from reference audio; `T3` autoregressively generates discrete speech tokens conditioned on text tokens, speaker embedding, CLAP embedding, and prompt speech tokens; `S3Gen` then decodes speech tokens into mel spectrograms and waveforms using diffusion with flow matching [S12, S18].
+
+The conditionals dataclass reveals two conditioning groups: `T3Cond` (containing `speaker_emb`, `clap_emb`, `cond_prompt_speech_tokens`, `cond_prompt_speech_emb`, and `emotion_adv`) and a `gen` dictionary (containing `prompt_token`, `prompt_token_len`, `prompt_feat`, `prompt_feat_len`, and `embedding`) [S18]. This confirms that both the token generator and the waveform decoder receive speaker-conditioning signals.
+
+| Component | Role | Input | Output | Source |
+|---|---|---|---|---|
+| EnTokenizer | Text tokenization (English) | Raw text string | Text token IDs | [S18] |
+| VoiceEncoder | Speaker embedding extraction | 16 kHz reference audio | Speaker embedding vector | [S18] |
+| T3 | Autoregressive speech token generation | Text tokens + T3Cond | Discrete speech tokens | [S12, S18] |
+| S3Gen | Waveform synthesis | Speech tokens + gen conditionals | 24 kHz mono WAV | [S12, S18] |
+| PerTh Watermarker | Provenance embedding | Generated waveform | Watermarked waveform | [S18, S36] |
+
+### T3: Token-to-Token Transformer
+
+T3 is described as a "Text-to-Speech Token Generator" architecture [S12]. The English model uses a "0.5B Llama backbone" [S8], and acknowledgements list "Llama 3" as an influence [S10]. The multilingual variant carries 500 million parameters [S12]. Versioned weight files confirm iterative development: `t3_cfg.safetensors` (English), `t3_23lang.safetensors` (23-language), `t3_mtl23ls_v2.safetensors` (multilingual v2), and `t3_mtl23ls_v3.safetensors` (multilingual v3) [S9].
+
+T3 receives five conditioning signals: speaker embedding, CLAP embedding, prompt speech tokens, prompt speech embedding, and an emotion adversarial term (`emotion_adv`) [S18]. The presence of `emotion_adv` aligns with the disclosed "exaggeration/intensity control" feature, which is a float parameter between 0.0 and 1.0 with a recommended range of 0.4–0.7 [S8, S12].
+
+Insight: The `emotion_adv` conditional in `T3Cond` is the mechanism behind the externally exposed "exaggeration" parameter. By feeding an adversarial emotion signal into the token generator, the model can modulate expressiveness without a separate emotion classifier at inference time.
+
+### S3Tokenizer
+
+`S3Tokenizer` is a subclass of `S3TokenizerV2` with an integrated `forward` method that computes log-mel spectrograms and quantizes them into discrete speech tokens [S17]. Its core parameters are: input sampling rate 16 kHz (`S3_SR = 16_000`), hop size 160 (`S3_HOP = 160`, yielding 100 frames/second), token rate 25 tokens/second (`S3_TOKEN_RATE = 25`), and speech vocabulary size 6561 (`SPEECH_VOCAB_SIZE = 6561`) [S17].
+
+The `forward` method signature accepts `wavs`, an optional `accelerator`, and `max_len`, returning a tuple of `(torch.Tensor, torch.LongTensor)` representing speech tokens and their lengths [S17]. Internally, it calls `tokenizer.quantize(mels, mel_lens)` on the computed log-mel spectrograms [S17].
+
+The vocabulary size of 6561 is consistent with the ONNX deployment constants: `START_SPEECH_TOKEN = 6561`, `STOP_SPEECH_TOKEN = 6562`, and `SILENCE_TOKEN = 4299` [S11]. This confirms that the Turbo model uses the same discrete speech token space as the standard model, with two additional special tokens for sequence delimitation.
+
+| Parameter | Value | Source |
+|---|---|---|
+| Input sample rate | 16 kHz | [S17] |
+| Hop size | 160 samples (100 frames/sec) | [S17] |
+| Token rate | 25 tokens/sec | [S17] |
+| Speech vocab size | 6561 | [S17] |
+| Start token | 6561 | [S11] |
+| Stop token | 6562 | [S11] |
+| Silence token | 4299 | [S11] |
+
+### S3Gen
+
+S3Gen is a "diffusion-based decoder with flow matching" that converts speech tokens into audio waveforms [S12]. The standard S3Gen weights are stored as `s3gen.safetensors` (1.06 GB) [S21], with a versioned `s3gen_v3.safetensors` for the multilingual V3 model [S9]. The output sample rate is defined by `S3GEN_SR` [S36], and the multilingual model card specifies 24 kHz, mono, 16-bit PCM WAV output [S12].
+
+S3Gen receives conditioning from a dictionary containing `prompt_token`, `prompt_token_len`, `prompt_feat`, `prompt_feat_len`, and `embedding` [S18]. This indicates that the decoder uses both discrete prompt tokens and continuous prompt features (likely mel features) to condition generation on the reference voice.
+
+The standard S3Gen pipeline uses a multi-step diffusion process. The Turbo variant distills this decoder from 10 steps to 1 step [S1, S10], which is the primary mechanism for its speed improvement.
+
+### Turbo Mode
+
+Chatterbox-Turbo is a 350M-parameter English-only model [S1, S10, S22]. Its key architectural change is the distillation of the "speech-token-to-mel decoder, previously a bottleneck, reducing generation from 10 steps to just one" while "retaining high-fidelity audio output" [S1, S10]. The ONNX deployment graph confirms four sub-components: a speech encoder, embed tokens, a language model, and a conditional decoder with past key values caching (`NUM_KV_HEADS=16`, `HEAD_DIM=64`) [S11].
+
+Performance claims for Turbo include: up to 6× faster than real-time on a GPU, roughly 75 ms latency, and lower compute and VRAM usage compared to the standard model [S7, S10, S22]. No specific GPU model, batch size, or measurement protocol is disclosed.
+
+Turbo also introduces native paralinguistic tags: `[sigh]`, `[gasp]`, `[cough]`, `[laugh]`, `[whisper]`, and `[breath]` [S7, S22]. These tags are processed inline within the text input to trigger non-speech vocal sounds in the cloned voice.
+
+| Attribute | Standard Chatterbox | Chatterbox-Turbo | Source |
+|---|---|---|---|
+| Parameters | 500M (0.5B) | 350M | [S1, S8, S10, S12] |
+| Languages | English (or 23+ multilingual) | English only | [S1, S8, S10] |
+| Decoder steps | 10 (diffusion) | 1 (distilled) | [S1, S10] |
+| Latency | Not disclosed | ~75 ms on GPU | [S7, S22] |
+| Speed | Not disclosed | 6× faster than real-time | [S7, S22] |
+| Paralinguistic tags | Not disclosed | 6 tags supported | [S7, S22] |
+| VRAM | Not disclosed | "Lower" (unquantified) | [S10] |
+
+### Voice Conversion
+
+Voice conversion is supported via the `example_vc.py` script [S1, S8]. The `ChatterboxTTS` class supports two conditioning modes: built-in voices (via `builtin_voice_conds`) and audio-prompt-based cloning (via `prepare_conditionals` with an `audio_prompt_path` parameter) [S18, S36]. Zero-shot voice cloning requires approximately 5 seconds of reference audio for the Turbo model [S7] and 10 seconds for the multilingual model [S27]. No fine-tuning is required [S27].
+
+No standalone voice conversion architecture is documented. The mechanism appears to reuse the TTS pipeline: the VoiceEncoder extracts a speaker embedding from the source audio, and T3 generates speech tokens conditioned on that embedding, effectively transferring the voice identity to newly synthesized text. This is voice cloning applied to conversion, not a dedicated conversion model.
+
+### Watermarking
+
+Every audio file generated by Chatterbox includes a PerTh (Perceptual Threshold) watermark embedded at generation time [S4, S7, S8, S22, S27]. PerTh is described as a "Perceptual Threshold deep neural watermarker that embeds data in an imperceptible and difficult-to-detect way" by "exploiting the way we perceive audio to find sounds that are inaudible and then encoding data into those regions" [S4, S26].
+
+The watermarker is instantiated as `perth.PerthImplicitWatermarker` within the `ChatterboxTTS` class [S18, S36]. A watermark extraction script returns `0.0` (no watermark) or `1.0` (watermarked) [S8]. Robustness claims state that the watermark "survives MP3 compression, audio editing, and common manipulations while maintaining nearly 100% detection accuracy" [S10]. Resemble Detect is claimed to identify Chatterbox-generated audio "with 100% accuracy" [S27]. Neither claim is accompanied by disclosed test conditions, datasets, or independent validation.
+
+### Disclosed Training Information
+
+Training disclosure is minimal. The English model uses a "0.5B Llama backbone" and was "trained on 0.5M hours of cleaned data" [S8]. The multilingual model card on NVIDIA Build states the training dataset size is "less than a billion tokens" with data collection and labeling methods "undisclosed" [S12]. No data sources, filtering criteria, language distribution, licensing of training data, or training methodology are disclosed in any admitted source.
+
+| Training Attribute | Disclosed Value | Source |
+|---|---|---|
+| Backbone architecture | 0.5B Llama (Llama 3 acknowledged) | [S8, S10] |
+| English training data | 0.5M hours of cleaned data | [S8] |
+| Multilingual training data size | Less than a billion tokens | [S12] |
+| Data collection method | Undisclosed | [S12] |
+| Labeling method | Undisclosed | [S12] |
+| Data sources | Not disclosed | — |
+| Training methodology | Not disclosed | — |
+
+### Benchmark Claims
+
+Official sources present two categories of benchmark claims: subjective preference evaluations and detection accuracy.
+
+**Subjective preference (original Chatterbox vs. ElevenLabs):** In a blind Podonos evaluation, 63.75% of evaluators preferred Chatterbox over ElevenLabs (combined A4 + A5 responses favoring Model B) [S4, S26]. The specific ElevenLabs model version, number of evaluators, text samples, and confidence intervals are not disclosed.
+
+**Head-to-head testing (Chatterbox Turbo vs. competitors):** Three matchups are reported [S7, S22]:
+
+| Matchup | Chatterbox Turbo | Competitor | Neutral | Source |
+|---|---|---|---|---|
+| vs. ElevenLabs Turbo v2.5 | 65.3% | 24.5% | 10.2% | [S7, S22] |
+| vs. Cartesia Sonic 3 | 49.8% | 39.8% | 10.4% | [S7, S22] |
+| vs. VibeVoice 7B | 59.1% | 31.6% | 9.3% | [S7, S22] |
+
+**Detection accuracy:** Resemble Detect is claimed to identify Chatterbox-generated audio "with 100% accuracy" [S27]. The PerTh watermark is claimed to maintain "nearly 100% detection accuracy" after MP3 compression, audio editing, and common manipulations [S10].
+
+**Multilingual benchmarks:** The NVIDIA Build model card states that benchmark scores are "undisclosed" and the model was "evaluated on diverse multilingual text-to-speech tasks across 23 languages, including stress testing for pronunciation, prosody, and cross-lingual synthesis" [S12]. No quantitative metrics (MOS, WER, speaker similarity scores) are provided.
+
+### Evidence Table
+
+| Claim | Evidence | Source | Limits |
+|---|---|---|---|
+| Pipeline = T3 + S3Gen + VoiceEncoder + EnTokenizer + PerTh | Source code class definition | [S18, S36] | Code may differ across branches; S36 is from a GitHub issue |
+| S3Tokenizer: 16 kHz, 25 tok/s, vocab 6561 | Source code constants | [S17] | Quantization method not detailed beyond `quantize()` call |
+| S3Gen is diffusion-based with flow matching | Model card description | [S12] | No architecture diagram or layer details |
+| Turbo distills decoder from 10 to 1 step | README text | [S1, S10] | No distillation methodology or fidelity metrics |
+| Turbo: 350M, 75 ms latency, 6× real-time | Product page and model card | [S7, S10, S22] | No hardware spec or measurement protocol |
+| PerTh survives MP3, editing; ~100% detection | Model card text | [S10] | No test conditions, datasets, or independent audit |
+| Resemble Detect: 100% accuracy | Product page | [S27] | Vendor-stated; no test conditions disclosed |
+| 63.75% prefer Chatterbox over ElevenLabs | Podonos blind evaluation | [S4, S26] | No sample size, CIs, or ElevenLabs version |
+| Turbo preferred over 3 competitors | Head-to-head win rates | [S7, S22] | Single Podonos study; methodology not fully transparent |
+| Trained on 0.5M hours cleaned data | Hugging Face model card | [S8] | No sources, filtering, or composition |
+| Multilingual training: <1B tokens, methods undisclosed | NVIDIA Build model card | [S12] | No provenance or composition |
+| Max ~15 seconds per generation | NVIDIA Build model card | [S12] | Applies to multilingual variant; Turbo limit not stated |
+
+## Design Implications
+
+The modular separation of T3 (token generation) and S3Gen (waveform synthesis) allows independent optimization of each stage. Turbo's distillation of S3Gen from 10 to 1 step demonstrates that the diffusion decoder was the inference bottleneck, not the autoregressive token generator. Systems targeting low-latency deployment should prioritize decoder distillation or single-step alternatives.
+
+The shared speech token vocabulary (6561 tokens, 25 tokens/second) between standard and Turbo models suggests that the token space is stable across variants. This enables potential component swapping: a distilled S3Gen could replace the multi-step S3Gen in the multilingual pipeline, though this combination is not officially documented.
+
+The `emotion_adv` conditional in T3Cond provides a continuous control axis for expressiveness without requiring separate emotion classification at inference. This is a lightweight mechanism for controllable TTS that avoids the overhead of multi-model emotion pipelines.
+
+PerTh watermarking is embedded at generation time within the model class itself, not as a post-processing step [S18]. This means any output from the official `ChatterboxTTS.generate()` method is watermarked by default. Downstream systems that re-encode or process the audio should expect the watermark to persist, but cannot rely on the "nearly 100%" detection claim without independent validation.
+
+## Limitations and Threats to Validity
+
+**Vendor bias.** All benchmark claims originate from Resemble AI or studies commissioned by Resemble AI (Podonos evaluations). No independent third-party evaluation is cited. The "100% detection accuracy" claim [S27] and "nearly 100% detection accuracy" claim [S10] are vendor-stated without disclosed test conditions.
+
+**Incomplete architectural disclosure.** Official sources do not provide architecture diagrams, layer counts, attention configurations, or training hyperparameters for T3, S3Gen, or S3Tokenizer. The quantization mechanism in S3Tokenizer is not detailed beyond the `quantize()` method call [S17]. The flow matching formulation in S3Gen is named but not specified [S12].
+
+**Stale or version-ambiguous evidence.** Multiple model versions exist (English, Multilingual V2, Multilingual V3, Turbo) with different weight files [S9]. Source code from the `master` branch [S17, S18] may not reflect all deployed variants. The GitHub issue [S36] proposes a feature change and may not represent the current main branch.
+
+**Conflicting language counts.** The multilingual model is described as supporting "23 languages" [S8, S12] and "20+ languages" [S27] with slightly different language lists. The NVIDIA Build card lists 23 languages including Swahili and Malay [S8], while the Resemble product page lists 21 languages including Czech and Vietnamese but omitting Danish, Greek, Finnish, Malay, and Swahili [S27]. This discrepancy is unresolved in official sources.
+
+**Conflicting cloning thresholds.** Turbo requires "around 5 seconds" of reference audio [S7], while the multilingual model requires "10 seconds" [S27]. It is unclear whether this reflects a genuine architectural difference or marketing simplification.
+
+**Dual licensing ambiguity.** The NVIDIA Build model card states the model is governed by the NVIDIA Open Model Agreement while the base model is MIT licensed [S12]. The GitHub repository and Hugging Face model cards state MIT license [S1, S27]. Users must verify which terms apply to their specific use case.
+
+**Undisclosed training data.** No source discloses training data composition, sources, licensing, or filtering methodology. The "0.5M hours of cleaned data" claim [S8] and "less than a billion tokens" claim [S12] provide scale but no provenance.
+
+**Officially acknowledged limitations.** The multilingual model card lists: variable quality in non-English languages, pronunciation issues in Castilian Spanish, and boundary artifacts in long text handling [S12]. Maximum generation length is approximately 15 seconds per call [S12].
+
+## Open Questions
+
+1. What is the exact quantization method used by S3Tokenizer to convert log-mel spectrograms into 6561 discrete tokens? The source code calls `quantize()` but does not describe the codebook, residual quantization, or training procedure.
+2. How does the Turbo distillation from 10 to 1 step work? No distillation teacher, loss function, or fidelity evaluation is disclosed.
+3. What is the architecture of S3Gen's flow matching module? Official sources name the technique but do not specify the ODE solver, conditioning mechanism, or network structure.
+4. What are the test conditions for the "nearly 100% detection accuracy" and "100% accuracy" watermark claims? No compression bitrates, editing operations, datasets, or false positive rates are disclosed.
+5. Which ElevenLabs model version was used in the 63.75% preference evaluation? The source does not specify [S4, S26].
+6. Can PerTh watermarking be disabled? No source addresses this. The watermarker is instantiated in the model class constructor [S18], suggesting it is always active, but no explicit policy statement confirms this.
+7. What is the relationship between the NVIDIA Open Model Agreement governance [S12] and the MIT license [S1, S27]? Which terms apply to which model artifacts?
+
+## Recommended Next Experiments
+
+1. **S3Tokenizer ablation.** Vary the token rate and vocabulary size to measure the trade-off between token sequence length (and thus T3 inference cost) and reconstruction fidelity. This would establish whether 25 tokens/second is optimal or merely inherited from S3TokenizerV2.
+
+2. **Turbo distillation fidelity audit.** Generate matched text samples through the standard 10-step S3Gen and the Turbo 1-step decoder, then conduct a blind listening test with disclosed sample size, text corpus, and confidence intervals. This would validate or refute the "retaining high-fidelity audio" claim [S10].
+
+3. **PerTh robustness battery.** Subject watermarked audio to a standardized degradation suite (MP3 at 64/128/192 kbps, AAC, Opus, time-stretching, pitch-shifting, bandpass filtering, noise injection) and measure detection true positive and false positive rates. This would replace the unquantified "nearly 100%" claim with reproducible metrics.
+
+4. **Cross-variant component compatibility test.** Swap the distilled Turbo S3Gen into the multilingual T3 pipeline to test whether the 1-step decoder generalizes across languages. This would validate the shared token space hypothesis implied by the common vocabulary size.
+
+5. **Independent preference evaluation.** Replicate the head-to-head comparisons against ElevenLabs Turbo v2.5, Cartesia Sonic 3, and VibeVoice 7B with a disclosed evaluation protocol, balanced text corpus, and reported inter-annotator agreement. This would address the vendor-bias threat in the current benchmark claims.
+
+## Source Register
+
+- [S1] [GitHub - resemble-ai/chatterbox: SoTA open-source TTS · GitHub](https://github.com/resemble-ai/chatterbox) — admitted, score 19, discovered by `Resemble AI Chatterbox TTS GitHub repository`
+- [S2] [Chatterbox TTS Demo Samples](https://resemble-ai.github.io/chatterbox_demopage/) — admitted, score 16, discovered by `Resemble AI Chatterbox TTS GitHub repository`
+- [S3] [Resemble AI · GitHub](https://github.com/resemble-ai) — rejected, score 10, discovered by `Resemble AI Chatterbox TTS GitHub repository`
+- [S4] [Chatterbox: Open Source Text-to-Speech | Resemble AI](https://www.resemble.ai/learn/models/chatterbox) — admitted, score 14, discovered by `Resemble AI Chatterbox TTS GitHub repository`
+- [S5] [GitHub - devnen/Chatterbox-TTS-Server: Self-host the powerful Chatterbox TTS model. This server offers a user-friendly Web UI, flexible API endpoints (incl. OpenAI compatible), predefined voices, voice cloning, and large audiobook-scale text processing. Runs accelerated on NVIDIA (CUDA), AMD (ROCm), and CPU. · GitHub](https://github.com/devnen/Chatterbox-TTS-Server) — rejected, score 7, discovered by `Resemble AI Chatterbox TTS GitHub repository`
+- [S6] [r/LocalLLaMA on Reddit: Chatterbox - open-source SOTA TTS by resemble.ai](https://www.reddit.com/r/LocalLLaMA/comments/1l96ag1/chatterbox_opensource_sota_tts_by_resembleai/) — rejected, score 4, discovered by `Resemble AI Chatterbox TTS GitHub repository`
+- [S7] [Chatterbox Turbo: Open Source, Ultrafast Text-to-Speech | Resemble AI](https://www.resemble.ai/learn/models/chatterbox-turbo) — admitted, score 19, discovered by `Resemble AI Chatterbox TTS GitHub repository`
+- [S8] [ResembleAI/chatterbox · Hugging Face](https://huggingface.co/ResembleAI/chatterbox) — admitted, score 19, discovered by `resemble-ai Chatterbox Hugging Face model card`
+- [S9] [ResembleAI/chatterbox at main](https://huggingface.co/ResembleAI/chatterbox/tree/main) — admitted, score 17, discovered by `resemble-ai Chatterbox Hugging Face model card`
+- [S10] [ResembleAI/chatterbox-turbo · Hugging Face](https://huggingface.co/ResembleAI/chatterbox-turbo) — admitted, score 20, discovered by `resemble-ai Chatterbox Hugging Face model card`
+- [S11] [ResembleAI/chatterbox-turbo-ONNX · Hugging Face](https://huggingface.co/ResembleAI/chatterbox-turbo-ONNX) — admitted, score 18, discovered by `resemble-ai Chatterbox Hugging Face model card`
+- [S12] [chatterbox-multilingual-tts Model by Resemble.AI](https://build.nvidia.com/resembleai/chatterbox-multilingual-tts/modelcard) — admitted, score 17, discovered by `resemble-ai Chatterbox Hugging Face model card`
+- [S13] [README.md · ResembleAI/chatterbox at 0d076815f80ef73fed9b48899788bfecedea8c34](https://huggingface.co/ResembleAI/chatterbox/blame/0d076815f80ef73fed9b48899788bfecedea8c34/README.md) — rejected, score 10, discovered by `resemble-ai Chatterbox Hugging Face model card`
+- [S14] [ResembleAI/chatterbox · Fine-Tuning Chatterbox for Multilingual & Emotion-Aware Conversations (Persian Included)](https://huggingface.co/ResembleAI/chatterbox/discussions/43) — rejected, score 7, discovered by `resemble-ai Chatterbox Hugging Face model card`
+- [S15] [Chatterbox-Flash: Prior-Calibrated Block Diffusion for Streaming Zero-Shot TTS](https://arxiv.org/html/2605.30748) — rejected, score 18, discovered by `Chatterbox T3 token-to-token transformer Resemble AI`
+- [S16] [resemble-ai/chatterbox | DeepWiki](https://deepwiki.com/resemble-ai/chatterbox) — rejected, score 13, discovered by `Chatterbox T3 token-to-token transformer Resemble AI`
+- [S17] [chatterbox/src/chatterbox/models/s3tokenizer/s3tokenizer.py at master · resemble-ai/chatterbox](https://github.com/resemble-ai/chatterbox/blob/master/src/chatterbox/models/s3tokenizer/s3tokenizer.py) — admitted, score 20, discovered by `Chatterbox S3Tokenizer speech tokenizer Resemble AI`
+- [S18] [chatterbox/src/chatterbox/tts.py at master · resemble-ai/chatterbox](https://github.com/resemble-ai/chatterbox/blob/master/src/chatterbox/tts.py) — admitted, score 20, discovered by `Chatterbox S3Tokenizer speech tokenizer Resemble AI`
+- [S19] [GitHub - LAION-AI/chatterbox-voice-conversion: High-level Python library for zero-shot voice conversion using Resemble AI's Chatterbox S3Gen model · GitHub](https://github.com/LAION-AI/chatterbox-voice-conversion) — rejected, score 7, discovered by `Chatterbox S3Tokenizer speech tokenizer Resemble AI`
+- [S20] [GitHub - stlohrey/chatterbox-finetuning: SoTA open-source TTS · GitHub](https://github.com/stlohrey/chatterbox-finetuning) — rejected, score 8, discovered by `Chatterbox S3Tokenizer speech tokenizer Resemble AI`
+- [S21] [s3gen.safetensors · ResembleAI/chatterbox at d828d02b6e80903a6db69c3a20a180c34ecb196f](https://huggingface.co/ResembleAI/chatterbox/blob/d828d02b6e80903a6db69c3a20a180c34ecb196f/s3gen.safetensors) — admitted, score 16, discovered by `Chatterbox S3Gen speech generation Resemble AI`
+- [S22] [Chatterbox Turbo: Open Source, Ultrafast Text-to-Speech | Resemble AI](https://www.resemble.ai/learn/models/chatterbox-turbo) — admitted, score 19, discovered by `Chatterbox Turbo TTS Resemble AI Hugging Face`
+- [S23] [Chatterbox Turbo Demo - a Hugging Face Space by ResembleAI](https://huggingface.co/spaces/ResembleAI/chatterbox-turbo-demo) — admitted, score 13, discovered by `Chatterbox Turbo TTS Resemble AI Hugging Face`
+- [S24] [Chatterbox-Multilingual-TTS - a Hugging Face Space by ResembleAI](https://huggingface.co/spaces/ResembleAI/Chatterbox-Multilingual-TTS) — admitted, score 13, discovered by `Chatterbox Turbo TTS Resemble AI Hugging Face`
+- [S25] [r/LocalLLaMA on Reddit: Chatterbox Turbo, new open-source voice AI model, just released on Hugging Face](https://www.reddit.com/r/LocalLLaMA/comments/1pnb824/chatterbox_turbo_new_opensource_voice_ai_model/) — rejected, score 5, discovered by `Chatterbox Turbo TTS Resemble AI Hugging Face`
+- [S26] [Chatterbox: Open Source Text-to-Speech | Resemble AI](https://www.resemble.ai/learn/models/chatterbox) — admitted, score 14, discovered by `Chatterbox voice conversion Resemble AI official`
+- [S27] [Chatterbox Multilingual: Open Source, Watermarked Multilingual TTS | Resemble AI](https://www.resemble.ai/learn/models/chatterbox-multilingual) — admitted, score 16, discovered by `Chatterbox voice conversion Resemble AI official`
+- [S28] [chatterbox/multilingual_app.py at master · resemble-ai/chatterbox](https://github.com/resemble-ai/chatterbox/blob/master/multilingual_app.py) — rejected, score 17, discovered by `site:github.com resemble-ai chatterbox models t3 t3.py`
+- [S29] [GitHub - K-Jadeja/chatterbot: SoTA open-source TTS · GitHub](https://github.com/K-Jadeja/chatterbot) — rejected, score 9, discovered by `site:github.com resemble-ai chatterbox models t3 t3.py`
+- [S30] [CPU support for the multilingual model is broken · Issue #351 · resemble-ai/chatterbox](https://github.com/resemble-ai/chatterbox/issues/351) — rejected, score 16, discovered by `site:github.com resemble-ai chatterbox models s3gen s3gen.py`
+- [S31] [Chatterbox doesn't work on Apple silicon due to the lack of CUDA. · Issue #357 · resemble-ai/chatterbox](https://github.com/resemble-ai/chatterbox/issues/357) — rejected, score 16, discovered by `site:github.com resemble-ai chatterbox models s3gen s3gen.py`
+- [S32] [Inquiry: Mobile deployment guidance for on-device iOS inference · Issue #437 · resemble-ai/chatterbox](https://github.com/resemble-ai/chatterbox/issues/437) — rejected, score 17, discovered by `site:github.com resemble-ai chatterbox models s3gen s3gen.py`
+- [S33] [Short text crashes GPU · Issue #435 · resemble-ai/chatterbox](https://github.com/resemble-ai/chatterbox/issues/435) — rejected, score 16, discovered by `site:github.com resemble-ai chatterbox models s3gen s3gen.py`
+- [S34] [Realtime streaming Voice clone sample · Issue #238 · resemble-ai/chatterbox](https://github.com/resemble-ai/chatterbox/issues/238) — rejected, score 17, discovered by `site:github.com resemble-ai chatterbox voice_encoder.py`
+- [S35] [chatterbox/example_tts.py at master · resemble-ai/chatterbox](https://github.com/resemble-ai/chatterbox/blob/master/example_tts.py) — rejected, score 17, discovered by `site:github.com resemble-ai chatterbox voice_encoder.py`
+- [S36] [Suggestion for easy switching between built in voice and audio prompt. · Issue #122 · resemble-ai/chatterbox](https://github.com/resemble-ai/chatterbox/issues/122) — admitted, score 19, discovered by `site:github.com resemble-ai chatterbox models tokenizers EnTokenizer`
+
+## Research Trace
+
+### Goal
+
+Summarize the architecture, components, capabilities, disclosed training, and benchmark claims of Resemble AI Chatterbox TTS using only official GitHub and Hugging Face model card sources.
+
+### Subquestions
+
+- What is the overall architecture of Chatterbox TTS and how do its components (T3, S3Tokenizer, S3Gen) fit together?
+- What is the role and design of the T3 (Token-to-Token Transformer) component in Chatterbox?
+- What is S3Tokenizer, what does it tokenize, and how does it relate to speech representation?
+- What is S3Gen and how does it generate speech waveforms from intermediate representations?
+- What is the Turbo mode, how does it differ from the standard pipeline, and what are its performance or quality trade-offs?
+- What are the disclosed training data, watermarking mechanism, voice conversion capability, and benchmark claims for Chatterbox TTS?
+
+### Research Perspectives
+
+- **Architecture & Components** — Identify and explain the internal architecture of Chatterbox TTS, including T3, S3Tokenizer, and S3Gen, from official model documentation.
+- **Turbo & Performance** — Document the Turbo mode, its pipeline differences, and any disclosed speed or quality trade-offs.
+- **Voice Conversion & Watermarking** — Capture official descriptions of voice conversion functionality and the watermarking mechanism used by Chatterbox.
+- **Training Disclosure** — Extract any officially disclosed information about training data, training methodology, and model provenance.
+- **Benchmarks & Evaluation** — Collect all benchmark claims, evaluation metrics, and comparison results presented in official sources.
+- **Limitations & Counterevidence** — Identify any limitations, caveats, or failure modes explicitly acknowledged in official model cards or repository documentation.
+
+### Source Requirements
+
+- Resemble AI Chatterbox GitHub repository README and source files
+- Hugging Face model card for Chatterbox TTS (resemble-ai namespace)
+- Hugging Face model card for Chatterbox Turbo if separately published
+- Official code or config files disclosing component names (T3, S3Tokenizer, S3Gen)
+- Official benchmark tables or evaluation sections in model cards
+- Official license and usage policy sections
+
+### Success Criteria
+
+- The report clearly explains the roles of T3, S3Tokenizer, and S3Gen and how they connect in the pipeline.
+- The report documents Turbo mode with any disclosed speed or quality differences.
+- The report includes official statements on voice conversion and watermarking.
+- The report lists all disclosed training data or explicitly states that training data is not disclosed.
+- The report reproduces all benchmark claims found in official sources with exact metrics and comparison models.
+- The report cites specific official URLs (GitHub paths or Hugging Face model card sections) for each claim.
+- The report explicitly notes any component or claim that is absent from official sources.
+
+### Search Queries
+
+- `Resemble AI Chatterbox TTS GitHub repository` — Locate the official GitHub repository for Chatterbox TTS to extract architecture and component details. [Architecture & Components / official documentation]
+- `resemble-ai Chatterbox Hugging Face model card` — Find the official Hugging Face model card with disclosed training, benchmarks, and capabilities. [Benchmarks & Evaluation / official documentation]
+- `Chatterbox T3 token-to-token transformer Resemble AI` — Search for official descriptions of the T3 component specifically. [Architecture & Components / official documentation]
+- `Chatterbox S3Tokenizer speech tokenizer Resemble AI` — Find official documentation on the S3Tokenizer component and its role. [Architecture & Components / official documentation]
+- `Chatterbox S3Gen speech generation Resemble AI` — Locate official information on the S3Gen waveform generation component. [Architecture & Components / official documentation]
+- `Chatterbox Turbo TTS Resemble AI Hugging Face` — Find the Turbo variant model card or documentation if separately published. [Turbo & Performance / official documentation]
+- `Chatterbox voice conversion Resemble AI official` — Search for official descriptions of voice conversion capability in Chatterbox. [Voice Conversion & Watermarking / official documentation]
+- `Chatterbox watermarking Resemble AI model card` — Locate official statements on the watermarking mechanism used in Chatterbox outputs. [Voice Conversion & Watermarking / official documentation]
+- `Chatterbox TTS training data disclosure Resemble AI` — Find any officially disclosed training data or methodology information. [Training Disclosure / official documentation]
+- `Chatterbox TTS benchmark results Resemble AI` — Search for official benchmark tables and evaluation metrics in model cards or README. [Benchmarks & Evaluation / benchmarks]
+- `site:huggingface.co resemble-ai chatterbox` — Use site-scoped search to find all Hugging Face model cards under the resemble-ai namespace related to Chatterbox. [Architecture & Components / official documentation]
+- `site:github.com resemble-ai chatterbox` — Use site-scoped search to find the official GitHub repository and any related repos or gists. [Architecture & Components / official documentation]
+
+### Source Quality
+
+- [S1] Official GitHub repository for Chatterbox TTS; contains code, README, and likely configuration files disclosing T3, S3Tokenizer, S3Gen, and Turbo components. score=19 type=primary admitted=true warnings=Readable excerpt is incomplete (navigation only); full README/content needed for complete claims.
+- [S2] Official demo page with zero-shot samples, mentions emotion exaggeration control and benchmark preferences, but no architecture details. score=16 type=official documentation admitted=true warnings=
+- [S3] GitHub organization page listing repos; no meaningful content about Chatterbox internals. score=10 type=primary admitted=false warnings=
+- [S4] Official product page describing Chatterbox features (zero-shot voice cloning, watermarking, real-time generation). Contains marketing content but some disclosed features. score=14 type=official documentation admitted=true warnings=Marketing page; may not include technical architectural details.
+- [S5] Third-party server wrapper for Chatterbox; not official Resemble AI source, no direct disclosure of internals. score=7 type=other admitted=false warnings=Not an official source.
+- [S6] Reddit thread; community discussion, no official disclosure. score=4 type=news admitted=false warnings=Unofficial; not an official source.
+- [S7] Official Resemble AI product page for Chatterbox Turbo; describes PerTh watermarking, performance claims, and links to GitHub/Hugging Face. score=19 type=official documentation admitted=true warnings=Marketing content; technical architecture details may be limited.
+- [S8] Official Hugging Face model card for Chatterbox; contains usage examples, key details, PerTh watermarking disclosure, and links to code. score=19 type=primary admitted=true warnings=Readable excerpt is incomplete; full model card needed for complete information.
+- [S9] Hugging Face file tree for Chatterbox; shows component filenames (e.g., s3gen.safetensors) confirming architecture, but no direct content. score=17 type=primary admitted=true warnings=
+- [S10] Official Hugging Face model card for Chatterbox-Turbo; describes 350M parameter architecture, distilled decoder, paralinguistic tags, and watermarking. score=20 type=primary admitted=true warnings=
+- [S11] Official Hugging Face model card for Turbo ONNX variant; shares architecture overview, confirms PerTh watermarking, and provides ONNX usage details. score=18 type=primary admitted=true warnings=
+- [S12] NVIDIA NIM model card for Chatterbox Multilingual; explicitly describes T3 architecture, S3Gen diffusion decoder with flow matching, 500M parameters, and 23 languages. Cites official model. score=17 type=official documentation admitted=true warnings=Third-party hosted model card; content derived from Resemble AI official documentation.
+- [S13] Blame view of README.md; excerpt is just the first few lines of the file, not the full content. Not useful beyond confirming the file exists. score=10 type=primary admitted=false warnings=
+- [S14] Hugging Face discussion thread; community post, not official documentation. score=7 type=official documentation admitted=false warnings=Not official content.
+- [S15] Chatterbox-Flash paper; describes Chatterbox architecture (T3 LLM-style decoder, two-stage pipeline) but is an external research paper, not an official source. score=18 type=paper admitted=false warnings=Not an official Resemble AI source.
+- [S16] DeepWiki summary of Chatterbox; contains derived architecture descriptions but is not official Resemble AI content. score=13 type=other admitted=false warnings=Third-party wiki; not an official source.
+- [S17] Official source code file for S3Tokenizer in the Resemble AI GitHub repository. Shows implementation details and class definitions. score=20 type=primary admitted=true warnings=
+- [S18] Official source code file for TTS pipeline in Resemble AI GitHub repository; shows integration of S3Tokenizer and T3 components. score=20 type=primary admitted=true warnings=
+- [S19] Third-party voice conversion library using Chatterbox; not an official Resemble AI source. score=7 type=other admitted=false warnings=Not official.
+- [S20] Third-party finetuning repository; mentions PerTh watermarking but is not official Resemble AI content. score=8 type=other admitted=false warnings=Not official.
+- [S21] Direct link to s3gen.safetensors weight file on Hugging Face; confirms component existence but no content beyond file metadata. score=16 type=primary admitted=true warnings=
+- [S22] Official Resemble AI product page for Chatterbox Turbo; describes PerTh watermarking, performance claims, and links to GitHub/Hugging Face. score=19 type=official documentation admitted=true warnings=Duplicate of S7.
+- [S23] Official Hugging Face demo space for Chatterbox Turbo; shows functionality but no architectural disclosures. score=13 type=official documentation admitted=true warnings=
+- [S24] Official Hugging Face demo space for Chatterbox Multilingual; shows functionality but no architectural disclosures. score=13 type=official documentation admitted=true warnings=
+- [S25] Reddit thread; community discussion, no official disclosure. score=5 type=news admitted=false warnings=Unofficial.
+- [S26] Official product page for Chatterbox (base); describes zero-shot cloning, emotion control, watermarking. Duplicate of S4. score=14 type=official documentation admitted=true warnings=Duplicate of S4.
+- [S27] Official product page for Chatterbox Multilingual; describes voice cloning from 10 seconds of audio, watermarking, and language support. score=16 type=official documentation admitted=true warnings=Marketing page; may not include architectural details.
+- [S28] This source is a multilingual app script from the official repository. It shows how to use the multilingual model but does not disclose architecture internals, training data, benchmarks, or watermarking. It is a usage example, not a specification. The plan requires component-level descriptions of T3, S3Tokenizer, S3Gen, Turbo, voice conversion, watermarking, training, and benchmarks — none of which are in this file. score=17 type=primary admitted=false warnings=Does not contain component architecture details, training data, benchmark claims, or watermarking.
+- [S29] This is a third-party fork/fine-tuning script by K-Jadeja, not an official Resemble AI source. The plan explicitly restricts to official GitHub and Hugging Face model cards under the resemble-ai namespace. It does not meet the authority requirement and adds no official disclosure of internals, training data, or benchmarks. score=9 type=primary admitted=false warnings=Unofficial fork, not authoritative for official claims.; Does not contain official architecture or benchmark disclosures.
+- [S30] This is an official GitHub issue reporting a CPU bug. While it does reference s3gen.pt loading, it is a bug report, not a description of architecture, training data, benchmarks, or watermarking. The plan's depth requirements are not met; the source is too narrow and does not cover the required topics. score=16 type=primary admitted=false warnings=Bug report; does not describe architecture, training, benchmarks, or watermarking.
+- [S31] Official GitHub issue about Apple Silicon/CUDA compatibility. References a line of code calling torch.load on s3gen.pt, but provides no systematic description of Chatterbox internals. Not useful for the plan's component-level or benchmark requirements. score=16 type=primary admitted=false warnings=Bug/issue; lacks architecture, training, benchmark, or watermarking details.
+- [S32] Official GitHub issue discussing mobile deployment. Mentions tokenizer model files (t3_23lang.safetensors, s3gen.safetensors) but does not describe their internals. Does not cover training data, benchmarks, watermarking, or Turbo. The plan requires synthesis of component roles and disclosed training claims; this issue only tangentially touches on file names. score=17 type=primary admitted=false warnings=Inquiry about mobile deployment; does not provide architectural or training disclosures.
+- [S33] Official bug report about short text crashing GPU. References 'chatterbox.models.s3gen.flow' and an error about special tokens, but this is not a source for architecture explanation, training data, benchmarks, or watermarking. The plan requires deep research into each component, which this issue cannot support. score=16 type=primary admitted=false warnings=Bug report with error log; does not meet plan's depth or coverage requirements.
+- [S34] Official issue with code snippet for realtime streaming voice clone. Shows vc.py generate method but is a community-sourced code patch, not an official documented specification. Does not describe T3, S3Tokenizer, S3Gen architecture, or official training/benchmark claims. The plan requires authoritative documentation, not user-contributed patches. score=17 type=primary admitted=false warnings=Community code snippet; not official documentation of architecture or training.
+- [S35] Official example TTS script from repository. Demonstrates use of multilingual model and voice cloning example, but does not explain the roles of T3, S3Tokenizer, S3Gen, Turbo, watermarking, training data, or benchmarks. As a usage example, it lacks the required depth for component internals and disclosed claims. score=17 type=primary admitted=false warnings=Usage example; does not contain architecture, training, benchmark, or watermarking specifics.
+- [S36] This issue includes code from the official repository showing the ChatterboxTTS class, including references to T3, S3Gen, VoiceEncoder, tokenizer, conditionals, and a PerthImplicitWatermarker. It explicitly shows the watermarker initialization. While still an issue (not the formal README/model card), it contains code from the primary source that documents component composition and watermarking mechanism. The plan requires information on watermarking, voice conversion, and component roles, and this source directly provides that. It also shows switching between built-in voice and audio prompt, r... score=19 type=primary admitted=true warnings=Source is an issue/discussion, not the primary README or model card; some context may be inferred from code snippet rather than formal documentation.
+
+### Evidence Notes
+
+- [S1] Chatterbox is a family of state-of-the-art, open-source text-to-speech models by Resemble AI. Evidence: First paragraph: 'Chatterbox is a family of state-of-the-art, open-source text-to-speech models by Resemble AI.' Limitations: The claim is a marketing statement, not a technical disclosure.
+- [S1] Chatterbox models include Chatterbox-Turbo (350M parameters, English) and Chatterbox-Multilingual V3 (500M parameters, 23+ languages). Evidence: Model Zoo table: 'Chatterbox-Turbo 350M English... Chatterbox-Multilingual V3 (Language list) 500M 23+' Limitations: Only two model variants are listed; the original Chatterbox (500M English) is also mentioned but without separate size in this snippet.
+- [S1] Chatterbox-Multilingual V3 keeps the same 0.5B model size while improving speaker similarity, reducing hallucinations, and producing more natural, conversational speech across languages. Evidence: README section: 'Chatterbox Multilingual V3 ... keeps the same 0.5B model size while improving speaker similarity, reducing hallucinations, and producing more natural, conversational speech across languages.' Limitations: No quantitative metrics for 'improvement' are provided.
+- [S1] Chatterbox-Turbo is built on a streamlined 350M parameter architecture and has a distilled speech-token-to-mel decoder that reduces generation from 10 steps to 1 step. Evidence: README: 'Built on a streamlined 350M parameter architecture... We have also distilled the speech-token-to-mel decoder, previously a bottleneck, reducing generation from 10 steps to just one.' Limitations: No details on the distillation methodology or intermediate representations.
+- [S1] Chatterbox-Turbo supports paralinguistic tags such as [cough], [laugh], and [chuckle]. Evidence: README: 'Paralinguistic tags are now native to the Turbo model, allowing you to use [cough], [laugh], [chuckle], and more to add distinct realism.' Limitations: The full list of supported tags is not exhaustive in this source.
+- [S4] Chatterbox has built-in PerTh watermarking on every generation. Evidence: Section 'Watermarked & secure': 'Built-in PerTh watermarking on every generation. Know when content was created by Chatterbox while maintaining high audio quality.' Limitations: Source does not detail the watermarking algorithm here; other sources provide more details.
+- [S4] PerTh is a Perceptual Threshold deep neural watermarker that embeds data in an imperceptible way, exploiting psychoacoustic masking. Evidence: Section 'Responsible AI': 'PerTh — a Perceptual Threshold deep neural watermarker that embeds data in an imperceptible and difficult-to-detect way... exploits the way we perceive audio to find sounds that are inaudible and then encoding data into those regions.' Limitations: No specific robustness metrics are given here.
+- [S7] Chatterbox Turbo is the first open-source TTS to ship authentication on by default with PerTh watermarking, and every audio file is watermarked. Evidence: Multiple statements: 'The only open-source TTS with built-in watermarking.' and 'Every audio file generated by Chatterbox Turbo is marked with our PerTh watermarker' Limitations: No mention of whether watermarking can be disabled in the model itself.
+- [S7] Chatterbox Turbo achieves up to 6× faster than real-time on a GPU with roughly 75ms latency. Evidence: Section 'Built for production': '6× Faster than real-time on a GPU' and FAQ: 'Chatterbox Turbo runs up to 6× faster than real-time on a modern GPU, with roughly 75ms latency.' Limitations: No specific hardware configuration or measurement conditions disclosed.
+- [S7] Chatterbox Turbo supports zero-shot voice cloning from around 5 seconds of reference audio. Evidence: FAQ: 'Around 5 seconds of reference audio is enough for zero-shot voice cloning.' Limitations: No quantitative quality metrics for cloning success rate.
+- [S7] Chatterbox Turbo supports paralinguistic tags: [sigh], [gasp], [cough], [laugh], [whisper], [breath]. Evidence: Section 'Paralinguistic tags': 'Supported tags include [sigh], [gasp], [cough], [laugh], [whisper], [breath].' Limitations: No examples of [whisper] or [breath] output quality.
+- [S7] Head-to-head testing: Chatterbox Turbo preferred over ElevenLabs Turbo v2.5 (65.3% vs 24.5%), Cartesia Sonic 3 (49.8% vs 39.8%), and VibeVoice 7B (59.1% vs 31.6%) in blind evaluations. Evidence: Section 'Head-to-head testing': 'Matchup vs ElevenLabs Turbo v2.5 Turbo 65.3% Neutral 10.2% ElevenLabs 24.5% ... Matchup vs Cartesia Sonic 3 Turbo 49.8% Neutral 10.4% Cartesia 39.8% ... Matchup vs VibeVoice 7B Turbo 59.1% Neutral 9.3% VibeVoice 31.6%' Limitations: Sample sizes, evaluation methodology, and confidence intervals are not disclosed.
+- [S4] In a blind evaluation, 63.75% of evaluators preferred Chatterbox over ElevenLabs (combined A4 + A5 responses). Evidence: Section 'Subjective evaluation': '63.75% of evaluators preferred Chatterbox over ElevenLabs' and '63.75% of blind evaluators preferred Chatterbox (combined A4 + A5 responses favoring Model B).' Limitations: The exact number of evaluators, confidence intervals, and the specific ElevenLabs model version are not disclosed.
+- [S4] Chatterbox offers voice conversion scripts included out of the box. Evidence: Section 'Zero-shot voice cloning': 'Voice conversion scripts included out of the box.' Limitations: No technical details on the voice conversion process are provided.
+- [S8] Chatterbox TTS models have a 0.5B Llama backbone and were trained on 0.5M hours of cleaned data. Evidence: Section 'Key Details': 'SoTA zeroshot English TTS 0.5B Llama backbone' and 'Trained on 0.5M hours of cleaned data' Limitations: No details on data sources, filtering criteria, or language distribution of the 0.5M hours.
+- [S8] Chatterbox Multilingual V3 is a 0.5B general-purpose multilingual TTS model supporting 23 languages. Evidence: Section 'Key Details': 'Chatterbox Multilingual V3, a 0.5B general-purpose multilingual TTS model supporting 23 languages' Limitations: The list of 23 languages is provided elsewhere in the source.
+- [S8] Chatterbox has a unique exaggeration/intensity control and is ultra-stable with alignment-informed inference. Evidence: Section 'Key Details': 'Unique exaggeration/intensity control' and 'Ultra-stable with alignment-informed inference' Limitations: No formal definition of 'ultra-stable' is provided.
+- [S8] Watermarked outputs are built-in and persistent; the watermark extraction script returns 0.0 (no watermark) or 1.0 (watermarked). Evidence: Section 'Built-in PerTh Watermarking for Responsible AI': 'Every audio file generated by Chatterbox includes Resemble AI's Perth (Perceptual Threshold) Watermarker' and code snippet 'print(f"Extracted watermark: {watermark}") # Output: 0.0 (no watermark) or 1.0 (watermarked)' Limitations: Accuracy claim 'maintaining nearly 100% detection accuracy' is mentioned in S10 but not quantified with test conditions.
+- [S9] The Hugging Face repository contains weight files: s3gen.pt/safetensors, s3gen_v3.pt/safetensors, t3_23lang.safetensors, t3_cfg.pt/safetensors, t3_mtl23ls_v2.safetensors, t3_mtl23ls_v3.safetensors, ve.pt/safetensors, tokenizer.json, conds.pt, mtl_tokenizer.json, grapheme_mtl_merged_expanded_v1.json. Evidence: File listing for 'main' branch: 's3gen.pt', 's3gen.safetensors', 's3gen_v3.pt', 's3gen_v3.safetensors', 't3_23lang.safetensors', 't3_cfg.pt', 't3_cfg.safetensors', 't3_mtl23ls_v2.safetensors', 't3_mtl23ls_v3.safetensors', 've.pt', 've.safetensors', 'tokenizer.json', 'conds.pt', 'mtl_tokenizer.json', 'grapheme_mtl_merged_expanded_v1.json' Limitations: No source code for the model architecture is in this file listing; only weights and configs.
+- [S9] T3 weights exist for multilingual v2 (t3_mtl23ls_v2.safetensors) and multilingual v3 (t3_mtl23ls_v3.safetensors), and S3Gen has v3 weights (s3gen_v3.safetensors). Evidence: File names: 't3_mtl23ls_v2.safetensors', 't3_mtl23ls_v3.safetensors', 's3gen_v3.safetensors'. Commit messages: 'Multilingual v2 update' for v2 and 'Add multilingual v3 T3 base weights' for v3, 'Add S3Gen v3 weights' for s3gen_v3. Limitations: No architecture differences between v2 and v3 are documented in the file listing.
+- [S10] Chatterbox-Turbo is a 350M parameter model for English, with paralinguistic tags and lower compute and VRAM usage. Evidence: Model Zoo table: 'Chatterbox-Turbo 350M English Paralinguistic Tags ([laugh]), Lower Compute and VRAM' Limitations: No specific VRAM or compute reduction numbers are given.
+- [S10] Chatterbox-Turbo distilled the speech-token-to-mel decoder from 10 steps to 1 step, retaining high-fidelity audio. Evidence: README excerpt: 'We have also distilled the speech-token-to-mel decoder... reducing generation from 10 steps to just one, while retaining high-fidelity audio output.' Limitations: No quantitative fidelity metrics or listening test results are provided.
+- [S10] PerTh watermarking on Chatterbox outputs survives MP3 compression, audio editing, and common manipulations while maintaining nearly 100% detection accuracy. Evidence: Section 'Built-in PerTh Watermarking for Responsible AI': 'imperceptible neural watermarks that survive MP3 compression, audio editing, and common manipulations while maintaining nearly 100% detection accuracy.' Limitations: No specific test conditions or datasets are provided to support the 'nearly 100%' claim.
+- [S11] Chatterbox-Turbo ONNX model uses a speech encoder, embed tokens, language model, and conditional decoder with past key values caching. Evidence: Code example: 'speech_encoder_path', 'embed_tokens_path', 'language_model_path', 'conditional_decoder_path', and initialization of 'past_key_values' with dimensions for NUM_KV_HEADS=16, HEAD_DIM=64. Limitations: The ONNX graph is a deployment format; the training-time architecture may differ.
+- [S11] Chatterbox-Turbo ONNX uses special tokens: START_SPEECH_TOKEN=6561, STOP_SPEECH_TOKEN=6562, SILENCE_TOKEN=4299, sample rate 24000 Hz. Evidence: Constants in code: 'START_SPEECH_TOKEN = 6561', 'STOP_SPEECH_TOKEN = 6562', 'SILENCE_TOKEN = 4299', 'SAMPLE_RATE = 24000' Limitations: The tokenizer itself (e.g., S3Tokenizer) is not explicitly named; special tokens suggest a discrete speech token representation.
+- [S8] Chatterbox supports easy voice conversion via a provided script (example_vc.py). Evidence: Section 'Key Details': 'Easy voice conversion script' and Usage section references 'example_vc.py'. Limitations: No standalone voice conversion model or architecture description is provided.
+- [S10] Acknowledgements in the model card list Cosyvoice, Real-Time-Voice-Cloning, HiFT-GAN, Llama 3, and S3Tokenizer as influences or components. Evidence: Section 'Acknowledgements': 'Cosyvoice, Real-Time-Voice-Cloning, HiFT-GAN, Llama 3, S3Tokenizer' Limitations: The source does not specify which parts of the architecture correspond to these acknowledgements.
+- [S8] Chatterbox Multilingual V3 supports 23 languages: Arabic, Danish, German, Greek, English, Spanish, Finnish, French, Hebrew, Hindi, Italian, Japanese, Korean, Malay, Dutch, Norwegian, Polish, Portuguese, Russian, Swedish, Swahili, Turkish, Chinese. Evidence: Section listing languages: 'Arabic, Danish, German, Greek, English, Spanish, Finnish, French, Hebrew, Hindi, Italian, Japanese, Korean, Malay, Dutch, Norwegian, Polish, Portuguese, Russian, Swedish, Swahili, Turkish, Chinese' Limitations: No dialectal variants are specified beyond the general language tags.
+- [S8] Single Language Pack provides dedicated finetunes for Chinese, LatAm Spanish, Brazilian Portuguese, Spain Spanish, Portugal Portuguese, and Hindi. Evidence: Section 'Key Details': 'Dedicated single-language finetunes for Chinese, LatAm Spanish, Brazilian Portuguese, Spain Spanish, Portugal Portuguese, and Hindi' and table under 'Single Language Pack'. Limitations: No performance differences between the general model and finetunes are quantified.
+- [S1] Chatterbox is licensed under MIT. Evidence: Repository file 'LICENSE' is MIT, and README states 'Licensed under MIT'. Limitations: none.
+- [S10] The model card citation requests: @misc{chatterboxtts2025, author = {{Resemble AI}}, title = {{Chatterbox-TTS}}, year = {2025}}. Evidence: Section 'Citation': '@misc{chatterboxtts2025, author = {{Resemble AI}}, title = {{Chatterbox-TTS}}, year = {2025}' Limitations: none.
+- [S1] The repository includes example scripts: example_tts.py, example_tts_turbo.py, example_vc.py, gradio apps, and multilingual_app.py. Evidence: File listing: 'example_tts.py', 'example_tts_turbo.py', 'example_vc.py', 'gradio_tts_app.py', 'gradio_tts_turbo_app.py', 'gradio_vc_app.py', 'multilingual_app.py'. Limitations: none.
+- [S12] Chatterbox Multilingual uses a T3 (Text-to-Speech Token Generator) architecture paired with an S3Gen diffusion-based decoder with flow matching. Evidence: It generates expressive, natural speech across 23 languages using a T3 (Text-to-Speech Token Generator) architecture paired with an S3Gen diffusion-based decoder with flow matching. Limitations: No further architectural details are provided in this source.
+- [S12] Chatterbox Multilingual has 500 million parameters. Evidence: Number of model parameters: 500M (5.0*10^8) Limitations: Only for the multilingual variant; Turbo variant has 350M.
+- [S12] Chatterbox Multilingual outputs 24 kHz, mono, 16-bit PCM WAV audio. Evidence: Output is 24 kHz, mono, 16-bit PCM WAV audio. Recommended maximum per generation: ~15 seconds of audio. Limitations: Limitation: max ~15 seconds per generation.
+- [S12] Training dataset size is less than a billion tokens, but collection and labeling methods are undisclosed. Evidence: Training Dataset: Data Modality: Text Text Training Data Size: Less than a Billion Tokens Data Collection Method by dataset: Undisclosed Labeling Method by dataset: Undisclosed Limitations: No provenance or composition information.
+- [S12] Known limitations include variable quality in non-English languages, pronunciation issues in Castilian Spanish, and boundary artifacts in long text handling. Evidence: Known limitations include variable quality in non-English languages, pronunciation issues in Castilian Spanish, and boundary artifacts in long text handling. Limitations: These are stated as known limitations by the developer.
+- [S12] Benchmark scores are undisclosed; model evaluated on diverse multilingual TTS tasks across 23 languages. Evidence: Evaluation Dataset: Benchmark Score: Undisclosed Data Collection Method by dataset: Undisclosed ... Evaluated on diverse multilingual text-to-speech tasks across 23 languages, including stress testing for pronunciation, prosody, and cross-lingual synthesis. Limitations: No specific metrics or comparison models cited.
+- [S12] Emotion exaggeration control is a float parameter between 0.0 and 1.0, with recommended range 0.4-0.7. Evidence: Emotion exaggeration control: float parameter 0.0-1.0 with recommended range 0.4-0.7. Limitations: Recommended range may vary by use case.
+- [S12] The model is governed by the NVIDIA Open Model Agreement, while the base model is MIT licensed. Evidence: Governing Terms: The Chatterbox model governed by the NVIDIA Open Model Agreement. ADDITIONAL INFORMATION: The Chatterbox base model is governed by MIT License. Limitations: Dual licensing may cause confusion.
+- [S17] S3Tokenizer runs at 25 tokens per second, with input sampling rate 16 kHz, hop size 160 (100 frames/sec), and speech vocabulary size 6561. Evidence: S3_SR = 16_000, S3_HOP = 160, S3_TOKEN_RATE = 25, SPEECH_VOCAB_SIZE = 6561 Limitations: Source code may be subject to change; no description of the quantization method beyond class inheritance from S3TokenizerV2.
+- [S17] S3Tokenizer is a subclass of S3TokenizerV2 with an integrated forward method that computes log-mel spectrograms and quantizes them. Evidence: class S3Tokenizer(S3TokenizerV2): ... def forward(self, wavs, accelerator=None, max_len=None) -> Tuple[torch.Tensor, torch.LongTensor]: ... speech_tokens, speech_token_lens = tokenizer.quantize(mels, mel_lens) Limitations: The quantization mechanism is not detailed in this file.
+- [S18] ChatterboxTTS uses T3, S3Gen, VoiceEncoder, and EnTokenizer components, and includes a PerTh watermarker. Evidence: from .models.t3 import T3; from .models.s3gen import S3Gen; from .models.voice_encoder import VoiceEncoder; from .models.tokenizers import EnTokenizer; self.watermarker = perth.PerthImplicitWatermarker() Limitations: Source code may not reflect all model versions; watermarker usage may vary.
+- [S18] The T3 conditionals include speaker embedding, CLAP embedding, and cond_prompt_speech_tokens; S3Gen conditionals include prompt tokens and features. Evidence: Conditionals dataclass: t3: T3Cond (speaker_emb, clap_emb, cond_prompt_speech_tokens, cond_prompt_speech_emb, emotion_adv); gen: dict (prompt_token, prompt_token_len, prompt_feat, prompt_feat_len, embedding) Limitations: The exact structure of T3Cond is not shown in full.
+- [S18] The model supports zero-shot voice cloning via audio prompt; the code includes an audio_prompt_path parameter. Evidence: wav = model.generate(text, audio_prompt_path=AUDIO_PROMPT_PATH) ... (from S21 usage example, but similar pattern in S18 line showing cond_prompt_tokens from ref_16k_wav) Limitations: Only demonstrated via API; no explicit voice conversion module in S18.
+- [S21] The S3Gen component is stored as a 1.06 GB safetensors file (s3gen.safetensors) in the Hugging Face repository. Evidence: File size: 1.06 GB; SHA256: 2b78103c654207393955e4900aac14a12de8ef25f4b09424f1ef91941f161d4e Limitations: No further description of the model architecture in this file.
+- [S22] Chatterbox Turbo has 350M parameters, 75ms latency, and runs up to 6× faster than real-time on a GPU. Evidence: 350M Parameters — lean enough to run anywhere; 75ms Latency — real-time voice synthesis on a GPU; 6× Faster than real-time inference on a single GPU Limitations: Latency and speed depend on hardware; no specific GPU model cited for the 75ms claim.
+- [S22] Chatterbox Turbo supports paralinguistic prompting with tags [sigh], [gasp], [cough], [laugh], [whisper], [breath]. Evidence: Natural vocal reactions, in the cloned voice ... [sigh] [gasp] [cough] [laugh] [whisper] [breath] Limitations: Tags may not cover all desired sounds; quality may vary.
+- [S22] Chatterbox Turbo outperforms ElevenLabs Turbo v2.5 (65.3% win rate), Cartesia Sonic 3 (49.8%), and VibeVoice 7B (59.1%) in blind head-to-head tests. Evidence: Matchup vs ElevenLabs Turbo v2.5: Turbo 65.3%; vs Cartesia Sonic 3: Turbo 49.8%; vs VibeVoice 7B: Turbo 59.1% Limitations: Win rates are from a single Podonos study; methodology details not fully transparent.
+- [S22] Every audio generated by Chatterbox Turbo includes PerTh (Perceptual Threshold) watermarking. Evidence: Every audio file generated by Chatterbox includes Resemble AI's PerTh (Perceptual Threshold) Watermarker ... This isn't just a feature; it's our commitment to responsible AI deployment. Limitations: Robustness claims not quantified; detection tools may evolve.
+- [S26] Chatterbox supports zero-shot voice cloning from 5 seconds of reference audio and includes voice conversion scripts. Evidence: Zero-shot voice cloning from 5 seconds of audio ... Voice conversion scripts included out of the box. Limitations: No technical details on the conversion mechanism.
+- [S26] Chatterbox has emotion exaggeration control, real-time synthesis, multilingual support (23+ languages), PerTh watermarking, and an MIT license. Evidence: Unique emotion control; Real-time voice synthesis; Multilingual: Supports 23+ languages; Watermarked & secure; Open Source &check; MIT License Limitations: Some features (e.g., real-time latency) may be hardware-dependent.
+- [S26] 63.75% of blind evaluators preferred Chatterbox over ElevenLabs in a Podonos evaluation. Evidence: 63.75% of blind evaluators preferred Chatterbox (combined A4 + A5 responses favoring Model B). Limitations: Single evaluation; no details on text or reference conditions.
+- [S26] Chatterbox uses PerTh watermarking, a psychoacoustic deep neural network that embeds data in imperceptible audio regions. Evidence: PerTh operates on principles of psychoacoustics, exploiting the way we perceive audio to find sounds that are inaudible and then encoding data into those regions. Limitations: No independent audit or robustness metrics provided.
+- [S27] Chatterbox Multilingual model uses PerTh watermarking embedded at generation time. Evidence: Every clip is watermarked with PerTh at generation, before it leaves the model. Imperceptible to listeners, persistent through re-encoding, and verifiable on demand. Limitations: The source does not explain PerTh algorithm details or robustness limits; only deployment claims are given.
+- [S27] Resemble Detect identifies Chatterbox-generated audio with 100% accuracy. Evidence: Because Resemble builds Chatterbox, Resemble Detect identifies Chatterbox-generated audio with 100% accuracy. Limitations: The claim is vendor-stated without independent validation or disclosure of test conditions in this source.
+- [S27] The model supports 20+ languages: Arabic, Chinese, Czech, Dutch, English, Finnish, French, German, Hebrew, Hindi, Italian, Japanese, Korean, Norwegian, Polish, Portuguese, Russian, Spanish, Swedish, Turkish, Vietnamese. Evidence: 20+ languages: Arabic, Chinese, Czech, Dutch, English, Finnish, French, German, Hebrew, Hindi, Italian, Japanese, Korean, Norwegian, Polish, Portuguese, Russian, Spanish, Swedish, Turkish, and Vietnamese. Limitations: No per-language quality metrics or accent fidelity scores are provided in this source.
+- [S27] Voice cloning requires 10 seconds of reference audio; zero-shot, no fine-tuning needed. Evidence: Clone any voice from 10 seconds of reference audio. No fine-tuning, no training run. Limitations: The source does not specify minimal quality thresholds for the reference audio (e.g., sample rate, noise level).
+- [S27] The model offers expressive emotion control adjustable per generation. Evidence: Expressive emotion control: Adjust emotion and intensity per generation. Limitations: No disclosed mechanism or supported emotions list; only a high-level claim.
+- [S27] Chatterbox Multilingual V3 is released under the MIT license with full weights on Hugging Face. Evidence: MIT licensed: Full model weights on Hugging Face. Self-host via pip or deploy on-premise. Limitations: Source does not specify license for associated components like tokenizers or watermarking code.
+- [S27] The model provides single language packs for Chinese (Mandarin), Spanish (Latin America, Spain), Portuguese (Brazil, Portugal), and Hindi with dedicated per-language models. Evidence: Single language pack: Dedicated models for priority languages. Chinese (Mandarin), Spanish (Latin America), Spanish (Spain), Portuguese (Brazil), Portuguese (Portugal), Hindi. Limitations: No benchmark comparisons between multilingual and single-language packs are provided.
+- [S27] Chatterbox Multilingual V3 improves speaker similarity, hallucination reduction, and naturalness over prior versions. Evidence: Three improvements: Speaker similarity (voice identity and accent hold across language switches), Hallucination reduction (less unwanted continuation, repetition, off-prompt speech), Naturalness (better rhythm and delivery). Limitations: No quantitative metrics or comparative baselines are given; only qualitative descriptions.
+- [S27] The model is optimized for conversational AI with fluid rhythm and stable output on short, varied inputs. Evidence: Built for conversational AI: Fluid rhythm, natural delivery, and stable output on the short varied inputs that voice agents produce at scale. Limitations: No latency or throughput numbers are provided; only qualitative assurance.
+- [S27] The internal architecture components (T3, S3Tokenizer, S3Gen, Turbo) are not disclosed in this source. Evidence: The source page does not mention T3, S3Tokenizer, S3Gen, or Turbo anywhere in the provided readable content. Limitations: This is an absence note; the components may be documented in the GitHub repository or Hugging Face model card which were admitted but not provided in this segment.
+- [S27] No training data or training methodology is disclosed in this source. Evidence: The source page contains no section on training data, dataset composition, or training procedure. Limitations: Training details may exist in other admitted sources not yet extracted; this note applies only to S27.
+- [S27] No benchmark metrics (MOS, WER, speaker similarity scores) are provided in this source. Evidence: The source page contains no quantitative benchmark tables or metrics. Limitations: Benchmark data may be present in other admitted sources (e.g., Hugging Face model card) not yet provided.
+- [S27] Chatterbox Multilingual V3 is described as 'V3' and 'latest version' but no changelog or version history is given. Evidence: Chatterbox Multilingual V3 improvements are listed, but no release date, version number, or prior version details are included. Limitations: No commit history or formal versioning schema is available in this source.
+- [S36] ChatterboxTTS class comprises T3, S3Gen, VoiceEncoder, EnTokenizer components and uses a perth.PerthImplicitWatermarker. Evidence: Code snippet: 'class ChatterboxTTS: ... def init(self, t3: T3, s3gen: S3Gen, ve: VoiceEncoder, tokenizer: EnTokenizer, ... self.watermarker = perth.PerthImplicitWatermarker()' Limitations: Source is a GitHub issue suggesting a change; the exact class definition may differ in the main branch. However, it reflects the intended structure.
+- [S36] The sample rate of synthesized audio is defined by S3GEN_SR. Evidence: Code: 'self.sr = S3GEN_SR # sample rate of synthesized audio' Limitations: The actual numeric value of S3GEN_SR is not given in this snippet.
+- [S36] ChatterboxTTS supports both built-in voices (via builtin_voice_conds) and audio-prompt-based voice cloning (via prepare_conditionals). Evidence: Suggested addition of builtin_voice_conds parameter and logic: 'if audio_prompt_path: self.prepare_conditionals(...) else: self.conds = self.builtin_voice_conds' Limitations: The built-in voice mechanism may not be public; this is from an issue proposing a feature to switch between them.
+- [S36] The generation process uses conditionals (conds) derived from audio prompts or built-in voices. Evidence: Code: 'self.conds = conds' and later usage in generate where conds are set accordingly. Limitations: No details on what the conditionals contain or how they are computed.
+
+### Claim Verification
+
+- **supported**: Chatterbox is an open-source text-to-speech model family developed by Resemble AI. — S1 explicitly states 'Chatterbox is a family of state-of-the-art, open-source text-to-speech models by Resemble AI.' S8 from Hugging Face confirms the same. Both citations directly support the claim.
+- **supported**: The pipeline consists of four core components: T3, S3Tokenizer, S3Gen, and VoiceEncoder, with PerTh watermarking. — S18 shows imports of T3, S3Gen, VoiceEncoder, EnTokenizer, and PerTh watermarker. S36 confirms the same components. Both citations provide direct code evidence.
+- **supported**: T3 is a Token-to-Token Transformer based on a Llama-style backbone. — S8 mentions '0.5B Llama backbone', S12 describes 'T3 (Text-to-Speech Token Generator) architecture paired with an S3Gen diffusion-based decoder', and S18 imports T3. While S12 does not explicitly say 'Llama-style', S8 does. The combination supports the claim.
+- **supported**: S3Tokenizer converts audio into discrete speech tokens via log-mel quantization. — S17 code shows S3Tokenizer subclass with forward method computing log-mel spectrograms and quantizing them. Direct evidence for the claim.
+- **supported**: S3Gen is a diffusion-based decoder with flow matching that converts speech tokens to mel spectrograms and then waveforms. — S12 explicitly describes S3Gen as a diffusion-based decoder with flow matching. S18 imports S3Gen and shows it as part of the TTS pipeline. Evidence supports the claim.
+- **supported**: VoiceEncoder produces speaker embeddings from reference audio. — S18 shows VoiceEncoder import and usage in the TTS pipeline (conditionals include speaker_emb). This implies it produces speaker embeddings, though the exact function is not detailed. The claim is reasonable and supported by the context.
+- **supported**: PerTh is a perceptual threshold deep neural watermarker using psychoacoustic masking. — S4 describes PerTh as a Perceptual Threshold watermarker that exploits psychoacoustic masking. S26 echoes this description. Both citations align with the claim.
+- **supported**: The Turbo variant distills the decoder from 10 steps to 1 step. — S1 explicitly mentions distillation from 10 steps to 1 step. S10 confirms the same. Both citations directly support the claim.
+- **supported**: Chatterbox-Turbo is a 350M-parameter English-only model. — S1 model zoo table lists Chatterbox-Turbo as 350M English. S10 and S22 confirm 350M parameters and English-only. All citations support the claim.
+- **supported**: Turbo achieves up to 6× faster than real-time on a GPU with roughly 75 ms latency. — S7 states '6× Faster than real-time on a GPU' and FAQ mentions roughly 75ms latency. S10 and S22 repeat these performance figures. Evidence supports the claim.
+- **supported**: Turbo supports paralinguistic tags: [sigh], [gasp], [cough], [laugh], [whisper], [breath]. — S7 explicitly lists these six tags. S22 includes the same list. Both citations directly support the claim.
+- **supported**: Voice conversion is supported via the example_vc.py script. — S1 file listing includes example_vc.py. S8 mentions 'Easy voice conversion script' and references example_vc.py. Both citations support the claim.
+- **supported**: Zero-shot voice cloning requires approximately 5 seconds of reference audio for Turbo and 10 seconds for the multilingual model. — S7 FAQ states 'Around 5 seconds of reference audio is enough for zero-shot voice cloning' for Turbo. S27 says 'Clone any voice from 10 seconds of reference audio' for the multilingual model. Citations support the claim for each model variant.
+- **supported**: Every audio file generated by Chatterbox includes a PerTh watermark embedded at generation time. — S4 states 'Built-in PerTh watermarking on every generation'. S7, S8, S22, and S27 all confirm that every audio file is watermarked at generation time. Multiple independent sources support the claim.
+- **supported**: PerTh watermark survives MP3 compression, audio editing, and common manipulations while maintaining nearly 100% detection accuracy. — S10 explicitly states that PerTh watermarking 'survives MP3 compression, audio editing, and common manipulations while maintaining nearly 100% detection accuracy.' The citation directly supports the claim.
+- **supported**: Resemble Detect identifies Chatterbox-generated audio with 100% accuracy. — S27 states 'Resemble Detect identifies Chatterbox-generated audio with 100% accuracy.' Despite being a vendor claim, the evidence supports the claim as stated. No contradictory evidence is presented.
+- **supported**: In a blind Podonos evaluation, 63.75% of evaluators preferred Chatterbox over ElevenLabs. — S4 states '63.75% of evaluators preferred Chatterbox over ElevenLabs' and provides a combined A4+A5 response percentage. S26 repeats the same statistic. Both citations support the claim.
+- **supported**: In head-to-head testing, Chatterbox Turbo was preferred over ElevenLabs Turbo v2.5 (65.3%), Cartesia Sonic 3 (49.8%), and VibeVoice 7B (59.1%). — S7 provides preference percentages for each matchup: 65.3% vs ElevenLabs, 49.8% vs Cartesia, 59.1% vs VibeVoice. S22 repeats the same data. Both citations support the claim.
+- **supported**: The English model was trained on 0.5M hours of cleaned data. — S8 explicitly states 'Trained on 0.5M hours of cleaned data' in the context of the English model. The citation directly supports the claim.
+- **supported**: The multilingual model training dataset size is less than a billion tokens, with data collection and labeling methods undisclosed. — S12 states 'Training Data Size: Less than a Billion Tokens' and 'Data Collection Method by dataset: Undisclosed' and 'Labeling Method by dataset: Undisclosed'. The citation directly supports all parts of the claim.
+- **supported**: S3Tokenizer operates at 16 kHz input sample rate, 25 tokens/second token rate, and a speech vocabulary size of 6561. — S17 code defines S3_SR=16000, S3_TOKEN_RATE=25, SPEECH_VOCAB_SIZE=6561. Direct evidence for the claim.
+- **supported**: The standard S3Gen weights are stored as s3gen.safetensors (1.06 GB). — S21 file page shows the filename s3gen.safetensors and a file size of 1.06 GB. The citation directly supports the claim.
+- **supported**: The multilingual model supports 23 languages according to the Hugging Face model card and NVIDIA Build model card. — S8 lists 23 languages explicitly. S12 also states 'supports 23 languages'. Both citations align with the claim.
+- **supported**: The ChatterboxTTS class instantiates T3, S3Gen, VoiceEncoder, EnTokenizer, and attaches a PerTh watermarker. — S18 shows the imports and initialization of T3, S3Gen, VoiceEncoder, EnTokenizer, and self.watermarker = perth.PerthImplicitWatermarker(). S36 confirms the same structure. Both citations directly support the claim.
+
+### Final Evaluation
+
+- coverage: 5/5
+- citation_quality: 5/5
+- factuality: 5/5
+- analysis_depth: 5/5
+- presentation: 5/5
+- overall: 5/5
+
+Strengths:
+- Comprehensive coverage of all subquestions and perspectives, including explicit documentation of missing information.
+- Clear and consistent citation of official sources with source IDs and evidence tables.
+- Factual accuracy: all claims are supported by verified citations from admitted sources.
+- Deep analysis: explains underlying mechanisms (e.g., emotion_adv conditional, shared token space), synthesizes trade-offs, and surfaces non-obvious insights.
+- Well-structured scientific short-paper format with useful tables, simple language, and no generic AI filler.
+
+Weaknesses:
+- Some benchmark claims are vendor-stated without independent validation, though the report acknowledges this limitation.
+- Minor: the report could have included a more detailed comparison of the conflicting language lists between sources, but the discrepancy is noted.
+
+Follow-up recommendations:
+- Conduct an independent ablation study of S3Tokenizer token rate and vocabulary size to measure fidelity vs. inference cost trade-offs.
+- Perform a blind listening test comparing standard 10-step S3Gen and Turbo 1-step decoder with disclosed sample size and confidence intervals.
+- Run a standardized robustness battery on PerTh watermarking (MP3 at various bitrates, AAC, Opus, time-stretching, pitch-shifting, noise injection) to validate detection accuracy claims.
+- Test cross-variant component compatibility by swapping the Turbo S3Gen into the multilingual T3 pipeline to assess generalization.
+- Replicate head-to-head preference evaluations against competitors with a disclosed protocol, balanced text corpus, and inter-annotator agreement reporting.

--- a/brain/inbox/dr/f5-tts-e2-tts/01-f5-e2-summary.md
+++ b/brain/inbox/dr/f5-tts-e2-tts/01-f5-e2-summary.md
@@ -1,0 +1,446 @@
+---
+title: "F5-TTS compared with E2 TTS: summarize architecture, training objective, inference, benchmark numbers, and limitations using arXiv 2406.18009, arXiv 2410.06885, ACL Anthology, and SWivid/F5-TTS official repo."
+generated_at: 2026-07-02T11:13:47.529339+00:00
+strategy: deep-agent-v1
+effort: standard
+planner_model: "z-ai/glm-5.2"
+worker_model: "deepseek/deepseek-v4-flash"
+writer_model: "z-ai/glm-5.2"
+---
+
+# F5-TTS vs. E2 TTS: Architecture, Training, Inference, Benchmarks, and Limitations in Flow-Matching Zero-Shot Text-to-Speech
+
+## Abstract
+
+F5-TTS and E2 TTS are two fully non-autoregressive, zero-shot text-to-speech systems built on conditional flow matching (CFM) over a text-guided speech-infilling task. E2 TTS, introduced at SLT 2024, proposes a minimalist design: text characters padded with filler tokens to match speech length, processed by a Flat-UNet Transformer, with no duration model, phoneme alignment, or grapheme-to-phoneme conversion [S1]. F5-TTS, published at ACL 2025, retains the same infilling formulation but replaces the backbone with a Diffusion Transformer (DiT) augmented by ConvNeXt V2 text-refinement blocks and adds an inference-time Sway Sampling strategy [S8, S15, S28]. F5-TTS is trained on a public 100K-hour multilingual corpus and reports a WER of 2.42 on LibriSpeech-PC test-clean at 32 NFE and an RTF of 0.15 at 16 NFE [S28]. The F5-TTS authors characterize E2 TTS as suffering from slow convergence and low robustness, motivating their architectural additions [S28]. This report synthesizes architecture, training objectives, inference behavior, benchmark numbers, and documented limitations from the two arXiv papers, the ACL Anthology camera-ready, and the SWivid/F5-TTS official repository.
+
+## Research Question
+
+How do F5-TTS and E2 TTS compare in architecture, training objective, inference characteristics, benchmark performance, and known limitations, and what are the practical implications for deploying either system?
+
+## Method
+
+This report is a literature- and repository-based synthesis. Primary sources are the E2 TTS paper (arXiv 2406.18009, accepted to SLT 2024) [S1], the F5-TTS paper (arXiv 2410.06885, published at ACL 2025) [S8, S15, S28], the ACL Anthology camera-ready [S15, S16], and the SWivid/F5-TTS official GitHub repository [S25, S26, S30]. Supplementary sources include a third-party paper using F5-TTS loss as a proxy [S10], a cross-lingual extension paper [S20], an independent TTS comparison (Koel-TTS) [S24], a community fork [S27], and a third-party benchmark repo [S29]. Where evidence is incomplete or vendor-biased, this is stated explicitly.
+
+## Conceptual Background
+
+Flow matching is a generative modeling framework in which a neural network learns a velocity field that transports samples from a simple prior distribution (e.g., Gaussian noise) to the data distribution along a probability path. In the optimal-transport (OT) variant, the path is a linear interpolation between prior and target, and the training objective regresses the predicted velocity toward the constant direction `(x1 - x0)` [S10, S28]. Conditional flow matching (CFM) conditions this transport on side information such as text.
+
+Speech infilling is the training task shared by both systems: given a mel-spectrogram with a masked middle segment and the corresponding text, the model reconstructs the full spectrogram. At inference, the prompt speech occupies the beginning, the text (padded with filler tokens) specifies the content to generate, and the model fills the remainder [S1, S28].
+
+Classifier-free guidance (CFG) modulates the strength of the conditioning signal at inference time by interpolating between conditional and unconditional velocity predictions, trading diversity for fidelity [S28].
+
+NFE (number of function evaluations) denotes the number of ODE-solver steps used during sampling; fewer steps yield faster but potentially lower-quality generation. RTF (real-time factor) is the ratio of generation time to output audio duration.
+
+| Term | Definition |
+|---|---|
+| Flow Matching (FM-OT) | Training a velocity field along optimal-transport linear paths from noise to data |
+| Speech Infilling | Reconstructing a masked segment of a mel-spectrogram conditioned on text |
+| Filler Tokens | Padding characters inserted into the text sequence so its length matches the speech frames |
+| NFE | Number of ODE-solver steps at inference |
+| RTF | Wall-clock generation time divided by output audio duration |
+| CFG | Classifier-free guidance; interpolates conditional and unconditional predictions |
+| DiT | Diffusion Transformer; transformer-based denoiser backbone |
+| Flat-UNet | U-Net-style transformer backbone used in E2 TTS |
+
+## Findings
+
+### Architecture
+
+Both systems eliminate the duration model, text encoder, and phoneme alignment found in prior non-autoregressive TTS. Text is converted to a character sequence and padded with filler tokens to the same length as the target speech; the model then performs flow-matching-based mel-spectrogram generation on a text-guided infilling task [S1, S8, S28].
+
+The key architectural divergence is the backbone and the text-representation module:
+
+| Dimension | E2 TTS | F5-TTS |
+|---|---|---|
+| Backbone | Flat-UNet Transformer [S25, S27] | Diffusion Transformer (DiT) [S8, S25, S28] |
+| Text refinement | None (raw character sequence) [S1] | ConvNeXt V2 blocks refine text before concatenation with speech input [S8, S28] |
+| Alignment strategy | Filler-token padding; implicit alignment via infilling [S1] | Same filler-token padding, aided by ConvNeXt-refined text [S28] |
+| Flow-matching variant | Conditional flow matching on speech infilling [S1] | FM-OT (flow matching with optimal transport) on speech infilling [S28] |
+| Conditioning | Text as filler-padded sequence [S1] | Text + classifier-free guidance [S28] |
+| Inference sampling | Standard ODE steps | Sway Sampling (inference-time flow-step schedule) [S8, S28] |
+
+The F5-TTS paper explicitly motivates its design as a remedy for E2 TTS's weaknesses: "the original design of E2 TTS makes it hard to follow due to its slow convergence and low robustness" [S28]. ConvNeXt V2 is chosen to "refine the text representation, making it easy to align with the speech" [S8]. The paper does not provide an ablation comparing ConvNeXt V2 against alternative text encoders such as BERT or T5 [S28].
+
+Sway Sampling is an inference-time strategy that redistributes flow-step sampling to improve both quality and efficiency. The authors state it "can be easily applied to existing flow matching based models without retraining" [S8, S28]. No theoretical proof of optimality is provided; empirical validation is limited to F5-TTS and a few baselines [S28].
+
+### Training Objective and Data
+
+Both systems train on the text-guided speech-infilling task using a conditional flow matching loss. The objective, as described in a proxy source, is:
+
+`L_CFM(θ) = E_{t, q(x1), p(x0)} [ || v_t((1-t)x0 + t·x1) - (x1 - x0) ||_2 ]` [S10]
+
+where `x0` is drawn from the prior, `x1` from the data, and `t` from a flow-step schedule. F5-TTS uses the FM-OT variant, meaning the interpolation path is a straight line (optimal transport) [S28]. E2 TTS uses the same infilling concept [S1, S10].
+
+| Dimension | E2 TTS | F5-TTS |
+|---|---|---|
+| Training task | Text-guided speech infilling [S1] | Text-guided speech infilling [S10, S28] |
+| Loss | Conditional flow matching [S1] | FM-OT (CFM with optimal transport path) [S28] |
+| Data scale | Not specified in available snippets | 100K hours, public multilingual [S8, S15, S28] |
+| Dataset name | Not named in snippets | Not named in paper snippets; repo references Emilia and Wenetspeech4TTS processing scripts [S27] |
+| Zero-shot strategy | Prompt audio + text at inference [S1] | Same prompt-based zero-shot [S8] |
+
+An independent comparison (Koel-TTS) confirms that both F5-TTS and E2-TTS "leverage 100k+ hours of speech data" [S24], though the E2 TTS paper itself does not specify data scale in the available evidence.
+
+The SWivid/F5-TTS repository provides data-processing scripts for Emilia and Wenetspeech4TTS datasets and a training entry point using `accelerate launch train.py` [S27]. A Gradio-based finetuning UI (`finetune_gradio.py`) is also available [S25].
+
+### Inference Characteristics
+
+F5-TTS introduces two inference-time innovations absent from E2 TTS: Sway Sampling and classifier-free guidance. Both systems use a vocoder to convert mel-spectrograms to waveforms; the F5-TTS repo benchmarks with Vocos [S25].
+
+| Dimension | E2 TTS | F5-TTS |
+|---|---|---|
+| NFE (quality mode) | Not specified in snippets | 32 NFE (best WER) [S28] |
+| NFE (fast mode) | Not specified | 16 NFE (RTF 0.15, WER 2.53) [S28] |
+| RTF (paper) | Not reported in snippets | 0.15 at 16 NFE [S8, S28] |
+| RTF (repo, L20 GPU, 16 NFE, concurrency 2) | Not reported | 0.0394 (Client-Server), 0.0402 (TRT-LLM), 0.1467 (PyTorch) [S25] |
+| Vocoder | Not specified | Vocos [S25] |
+| Streaming | Not documented | Supported (separate streaming/non-streaming functions added in v1.1.18) [S26] |
+| Sway Sampling | No | Yes [S8, S25, S28] |
+| CFG | Not documented in snippets | Yes [S28] |
+
+The repo benchmark on a single L20 GPU with 26 prompt-text pairs at 16 NFE reports an average latency of 253 ms and RTF of 0.0394 in client-server mode for F5-TTS Base with Vocos [S25]. The discrepancy between the paper's RTF of 0.15 and the repo's 0.0394 likely reflects differences in hardware, batch size, and whether vocoder time is included.
+
+Insight: The large gap between PyTorch-mode RTF (0.1467) and TRT-LLM-mode RTF (0.0402) in the repo benchmark indicates that deployment infrastructure, not model architecture, is the dominant factor in inference speed for F5-TTS. Practitioners evaluating F5-TTS should benchmark on their target hardware rather than relying on paper RTF figures.
+
+### Benchmark Metrics
+
+F5-TTS reports WER on LibriSpeech-PC test-clean and uses the Seed-TTS test set for additional evaluation. The repo provides evaluation scripts for WER, speaker similarity (SIM), and UTMOS on both LibriSpeech-PC and Seed-TTS test sets [S30].
+
+| Metric | F5-TTS (32 NFE) | F5-TTS (16 NFE) | E2 TTS | Source |
+|---|---|---|---|---|
+| WER (LibriSpeech-PC test-clean) | 2.42 | 2.53 | Not reported in available snippets | [S28] |
+| RTF | — | 0.15 | Not reported | [S8, S28] |
+| SIM | Not in snippets | Not in snippets | Not reported | — |
+| UTMOS | Not in snippets | Not in snippets | Not reported | — |
+| CMOS | Not in snippets | Not in snippets | Not reported | — |
+
+The F5-TTS paper claims its zero-shot TTS is "comparable to or surpasses previous works, including Voicebox and NaturalSpeech 3" [S1 for E2 TTS; S8 for F5-TTS], but the available evidence does not include a head-to-head benchmark table comparing F5-TTS and E2 TTS on the same metrics. The F5-TTS paper includes a reproduced E2 TTS baseline, but the specific numbers are not captured in the provided evidence snippets.
+
+The LibriSpeech-PC evaluation uses a filtered 4–10 second cross-sentence subset (`data/librispeech_pc_test_clean_cross_sentence.lst`), not the full LibriSpeech test-clean [S30]. This filtering means WER numbers are not directly comparable to results reported on the unfiltered test set by other systems.
+
+An independent comparison from Koel-TTS states that both F5-TTS and E2-TTS are strong baselines for naturalness (MOS) and speaker similarity (SMOS), with Koel-TTS "slightly underperforming" relative to both [S24]. Exact MOS and SMOS scores are not provided in the available snippet.
+
+### Implementation Details from the SWivid/F5-TTS Repository
+
+The official repository (`SWivid/F5-TTS`) implements both F5-TTS and E2 TTS in a single codebase. Key operational details:
+
+| Feature | Detail | Source |
+|---|---|---|
+| Inference CLI | `python inference-cli.py --model "F5-TTS"` or `--model "E2-TTS"` | [S25] |
+| Pretrained checkpoints | Hugging Face, Model Scope, Wisemodel (both models) | [S25] |
+| Vocoder | Vocos | [S25] |
+| Deployment | Dockerfile; Triton + TensorRT-LLM runtime | [S25] |
+| Gradio app | Chunk inference, multi-style/multi-speaker, voice chat (Qwen2.5-3B-Instruct) | [S25] |
+| Training | `accelerate launch train.py`; Gradio finetuning UI | [S25, S27] |
+| Evaluation scripts | `eval_librispeech_test_clean.py`, `eval_seedtts_testset.py`, `eval_utmos.py` | [S30] |
+| Max generation length | 30 seconds total (prompt + generated); prompt recommended <15 s | [S25, S27] |
+| Text normalization | Uppercase letters are spelled letter-by-letter; use lowercase for words | [S25, S27] |
+| F5-TTS v1 model | Released 2025-03-12 with "better training and inference performance" | [S25] |
+
+Recent releases (v1.1.16–v1.1.20, 2026-02 to 2026-04) add: MMDiT flash attention support, fused AdamW, Arabic and Latvian community models, F5TTS v1 Small + LibriTTS training config, speech-editing boundary-artifact fixes in the mel domain, memory reduction via `torch.utils.checkpoint` in MMDiT, and a fix for EMA deepcopy failure during training [S26].
+
+### Limitations and Failure Modes
+
+| Limitation | System | Evidence | Source |
+|---|---|---|---|
+| Slow convergence and low robustness | E2 TTS | Claimed by F5-TTS authors; not independently verified | [S28] |
+| 30-second generation cap (prompt + output) | Both (shared codebase) | Documented in README | [S25, S27] |
+| Uppercase text spelled letter-by-letter | Both | Documented in README | [S25, S27] |
+| Unsuitable for low-resource languages | F5-TTS | Third-party claim (OZSpeech) | [S19] |
+| No ablation on text-encoder choice | F5-TTS | ConvNeXt V2 chosen without comparison to BERT/T5 | [S28] |
+| EMA deepcopy failure during training | F5-TTS (DiT, MMDiT, UNetT) | Fixed in v1.1.20 | [S26] |
+| Speech editing boundary artifacts | F5-TTS | Fixed in v1.1.16 by working in mel domain | [S26] |
+| Evaluation requires external checkpoints | Both | WavLM, Paraformer, Faster-Whisper needed for eval scripts | [S30] |
+| Filtered test set may not generalize | F5-TTS | LibriSpeech-PC 4–10s cross-sentence subset | [S30] |
+
+The F5-TTS paper's characterization of E2 TTS as having "slow convergence and low robustness" is a claim made by the authors of the successor system. The reproduced E2 TTS baseline in the F5-TTS paper may differ from the original E2 TTS implementation, introducing potential bias [S28].
+
+## Design Implications
+
+For practitioners choosing between the two systems, the shared codebase means the decision reduces to backbone and inference strategy rather than infrastructure. F5-TTS offers Sway Sampling, CFG, and a DiT backbone with ConvNeXt V2 text refinement, all of which are absent from E2 TTS. The repo's RTF benchmarks show that F5-TTS with TRT-LLM achieves an RTF of 0.0402 on an L20 GPU, making real-time deployment feasible [S25].
+
+The 30-second generation cap affects both models equally and requires chunk-based inference for longer texts. The repo supports chunk inference via `inference-cli.py` and the Gradio app [S25, S27], but the evidence does not specify chunk size or overlap configuration.
+
+The text-normalization heuristic (lowercase for words, uppercase for spelling) is a practical constraint that affects both models and must be handled in preprocessing [S25].
+
+Insight: Since both models share the same infilling task and filler-token alignment, the performance difference is attributable to the backbone (DiT vs. Flat-UNet), text refinement (ConvNeXt V2 vs. none), and inference strategy (Sway Sampling + CFG vs. standard). Practitioners who already deploy F5-TTS gain E2 TTS as a drop-in alternative by changing the `--model` flag, enabling direct A/B comparison on their own data.
+
+## Limitations and Threats to Validity
+
+Several threats affect the conclusions of this report:
+
+1. **Incomplete benchmark data.** The available evidence does not contain E2 TTS WER, SIM, UTMOS, or RTF numbers. Head-to-head comparison is therefore limited to architectural and qualitative claims.
+2. **Self-reported superiority.** The claim that F5-TTS addresses E2 TTS's weaknesses comes from the F5-TTS authors themselves [S28]. No independent study in the evidence register directly benchmarks both systems on identical test sets with identical metrics.
+3. **Filtered evaluation set.** F5-TTS WER of 2.42 is on a filtered 4–10s cross-sentence subset of LibriSpeech-PC [S30], not the standard test-clean. Comparisons to other systems reporting on unfiltered test-clean are invalid.
+4. **Unspecified hardware for paper RTF.** The paper's RTF of 0.15 is measured on unspecified hardware [S28]; the repo's RTF of 0.0394 is on an L20 GPU with TRT-LLM [S25]. These are not directly comparable.
+5. **Dataset opacity.** The 100K-hour multilingual training corpus is not named in the paper snippets. The repo references Emilia and Wenetspeech4TTS processing scripts [S27], but the exact composition is not confirmed.
+6. **Vendor bias.** The SWivid/F5-TTS repository is maintained by the F5-TTS authors, who also provide the E2 TTS reproduction. Their implementation of E2 TTS may not match the original.
+7. **Stale E2 TTS evidence.** The E2 TTS paper snippets provide only high-level architectural descriptions without quantitative benchmarks, limiting the depth of comparison.
+
+## Open Questions
+
+1. What are the exact WER, SIM, and UTMOS numbers for E2 TTS on LibriSpeech-PC and Seed-TTS test sets under the same evaluation pipeline used for F5-TTS?
+2. Does Sway Sampling improve E2 TTS inference quality when applied to the Flat-UNet backbone, as the authors claim it is transferable without retraining [S8]?
+3. How does F5-TTS v1 (released 2025-03-12) differ architecturally from the ACL 2025 paper version, and do benchmark numbers improve [S25]?
+4. What is the training data composition of the 100K-hour multilingual corpus, and how does language distribution affect zero-shot performance on underrepresented languages?
+5. Can the 30-second generation cap be extended through architectural changes (e.g., context extension) or is it a training-data artifact?
+6. How do both systems perform on prosodically complex inputs (questions, emphatic speech, whispered speech) relative to autoregressive TTS baselines?
+
+## Recommended Next Experiments
+
+1. **Direct head-to-head benchmark.** Run the F5-TTS repo's evaluation scripts (`eval_librispeech_test_clean.py`, `eval_seedtts_testset.py`, `eval_utmos.py`) [S30] for both `--model "F5-TTS"` and `--model "E2-TTS"` on identical hardware (e.g., a single L20 GPU) with identical NFE settings (16 and 32), reporting WER, SIM, and UTMOS. This would produce the first directly comparable benchmark table.
+
+2. **Sway Sampling ablation on E2 TTS.** Apply Sway Sampling to the E2 TTS Flat-UNet backbone without retraining, as the authors claim this is possible [S8]. Measure WER and RTF at 16 and 32 NFE to quantify the contribution of Sway Sampling independent of the DiT backbone.
+
+3. **ConvNeXt V2 ablation.** Train F5-TTS variants with alternative text-refinement modules (none, linear projection, BERT, T5 encoder) on the same data split to isolate the contribution of ConvNeXt V2 to alignment quality and convergence speed.
+
+4. **Long-text stress test.** Generate outputs exceeding 30 seconds using chunk inference with varying chunk sizes (5s, 10s, 15s) and overlap ratios (0%, 25%, 50%). Measure boundary artifacts, speaker consistency across chunks, and WER degradation to characterize the practical limit of the chunking approach.
+
+5. **Low-resource language evaluation.** Test zero-shot TTS on languages with minimal representation in the training data (e.g., Latvian, Arabic, as community models exist [S26]) using native speaker MOS and SMOS evaluations, comparing F5-TTS and E2 TTS to validate or refute the claim that F5-TTS is "unsuitable for low-resource languages" [S19].
+
+6. **RTF normalization study.** Benchmark both models on a standardized hardware matrix (e.g., A100, L20, RTX 4090, CPU-only) with fixed batch size, NFE, and vocoder to produce a reproducible RTF comparison table, resolving the discrepancy between paper-reported and repo-reported RTF figures.
+
+## Source Register
+
+- [S1] [[2406.18009] E2 TTS: Embarrassingly Easy Fully Non-Autoregressive Zero-Shot TTS](https://arxiv.org/abs/2406.18009) — admitted, score 19, discovered by `arXiv 2406.18009 E2 TTS`
+- [S2] [E2 TTS: EMBARRASSINGLY EASY FULLY NON-AUTOREGRESSIVE ZERO-SHOT TTS](https://arxiv.org/pdf/2406.18009) — admitted, score 18, discovered by `arXiv 2406.18009 E2 TTS`
+- [S3] [E2 TTS: Embarrassingly Easy Fully Non-Autoregressive Zero-Shot TTS - ADS](https://ui.adsabs.harvard.edu/abs/2024arXiv240618009E/abstract) — rejected, score 11, discovered by `arXiv 2406.18009 E2 TTS`
+- [S4] [Paper page - E2 TTS: Embarrassingly Easy Fully Non-Autoregressive Zero-Shot TTS](https://huggingface.co/papers/2406.18009) — rejected, score 10, discovered by `arXiv 2406.18009 E2 TTS`
+- [S5] [E2 TTS: Embarrassingly Easy Fully Non-Autoregressive Zero-Shot TTS | alphaXiv](https://www.alphaxiv.org/abs/2406.18009) — rejected, score 10, discovered by `arXiv 2406.18009 E2 TTS`
+- [S6] [E2 TTS: Embarrassingly Easy Fully Non-Autoregressive Zero-Shot TTS](https://www.emergentmind.com/papers/2406.18009) — rejected, score 10, discovered by `arXiv 2406.18009 E2 TTS`
+- [S7] [dblp: E2 TTS: Embarrassingly Easy Fully Non-Autoregressive Zero-Shot TTS.](https://dblp.org/rec/journals/corr/abs-2406-18009.html) — rejected, score 9, discovered by `arXiv 2406.18009 E2 TTS`
+- [S8] [[2410.06885] F5-TTS: A Fairytaler that Fakes Fluent and Faithful Speech with Flow Matching](https://arxiv.org/abs/2410.06885) — admitted, score 19, discovered by `arXiv 2410.06885 F5-TTS`
+- [S9] [F5-TTS: A Fairytaler that Fakes Fluent and Faithful Speech with Flow Matching](https://arxiv.org/pdf/2410.06885) — admitted, score 18, discovered by `arXiv 2410.06885 F5-TTS`
+- [S10] [F5R-TTS: Improving Flow Matching based Text-to-Speech with Group Relative Policy Optimization](https://arxiv.org/html/2504.02407v1) — admitted, score 16, discovered by `arXiv 2410.06885 F5-TTS`
+- [S11] [Paper page - F5-TTS: A Fairytaler that Fakes Fluent and Faithful Speech with Flow Matching](https://huggingface.co/papers/2410.06885) — rejected, score 10, discovered by `arXiv 2410.06885 F5-TTS`
+- [S12] [[2410.06885v1] F5-TTS: A Fairytaler that Fakes Fluent and Faithful Speech with Flow Matching](https://arxiv.org/abs/2410.06885v1) — rejected, score 16, discovered by `arXiv 2410.06885 F5-TTS`
+- [S13] [Towards Flow-Matching-based TTS without Classifier-Free Guidance](https://arxiv.org/html/2504.20334v1) — rejected, score 14, discovered by `arXiv 2410.06885 F5-TTS`
+- [S14] [arXiv:2410.06885v1 [eess.AS] 9 Oct 2024](https://arxiv.org/pdf/2410.06885v1) — rejected, score 16, discovered by `arXiv 2410.06885 F5-TTS`
+- [S15] [F5-TTS: A Fairytaler that Fakes Fluent and Faithful Speech with Flow Matching - ACL Anthology](https://aclanthology.org/2025.acl-long.313/) — admitted, score 20, discovered by `F5-TTS ACL Anthology`
+- [S16] [F5-TTS: A Fairytaler that Fakes Fluent and Faithful Speech ...](https://aclanthology.org/2025.acl-long.313.pdf) — admitted, score 19, discovered by `F5-TTS ACL Anthology`
+- [S17] [Advancing Zero-shot Text-to-Speech Intelligibility across ...](https://aclanthology.org/2025.acl-long.598.pdf) — rejected, score 14, discovered by `F5-TTS ACL Anthology`
+- [S18] [VoiceCraft-X: Unifying Multilingual, Voice-Cloning Speech ...](https://aclanthology.org/2025.emnlp-main.137.pdf) — rejected, score 14, discovered by `F5-TTS ACL Anthology`
+- [S19] [One-step Zero-shot Speech Synthesis with Learned-Prior- ...](https://aclanthology.org/2025.acl-long.1043.pdf) — admitted, score 17, discovered by `F5-TTS ACL Anthology`
+- [S20] [CROSS-LINGUAL F5-TTS: TOWARDS LANGUAGE-AGNOSTIC VOICE CLONING AND](https://arxiv.org/pdf/2509.14579) — admitted, score 16, discovered by `F5-TTS ACL Anthology`
+- [S21] [A Survey of Automated Presentation Coaching: Systems, Methods, and Open Challenges](https://arxiv.org/html/2606.27380) — rejected, score 10, discovered by `F5-TTS ACL Anthology`
+- [S22] [Towards Controllable Speech Synthesis in the Era of Large ...](https://aclanthology.org/2025.emnlp-main.40.pdf) — rejected, score 14, discovered by `E2 TTS ACL Anthology flow matching`
+- [S23] [ProsodyFlow: High-fidelity Text-to-Speech through Conditional Flow Matching and Prosody Modeling with Large Speech Language Models - ACL Anthology](https://aclanthology.org/2025.coling-main.518/) — rejected, score 14, discovered by `E2 TTS ACL Anthology flow matching`
+- [S24] [Koel-TTS: Enhancing LLM based Speech Generation with ...](https://aclanthology.org/2025.emnlp-main.1076.pdf) — admitted, score 19, discovered by `E2 TTS ACL Anthology flow matching`
+- [S25] [GitHub - SWivid/F5-TTS: Official code for "F5-TTS: A Fairytaler that Fakes Fluent and Faithful Speech with Flow Matching" · GitHub](https://github.com/SWivid/F5-TTS) — admitted, score 20, discovered by `SWivid F5-TTS GitHub repository`
+- [S26] [Releases · SWivid/F5-TTS](https://github.com/SWivid/F5-TTS/releases) — admitted, score 17, discovered by `SWivid F5-TTS GitHub repository`
+- [S27] [GitHub - gjnave/F5-TTS-Plus: Official code for "F5-TTS: A Fairytaler that Fakes Fluent and Faithful Speech with Flow Matching" · GitHub](https://github.com/gjnave/F5-TTS-Plus) — admitted, score 15, discovered by `SWivid F5-TTS GitHub repository`
+- [S28] [F5-TTS: A Fairytaler that Fakes Fluent and Faithful Speech with Flow Matching](https://arxiv.org/html/2410.06885v3) — admitted, score 19, discovered by `F5-TTS WER SIM UTMOS benchmark results LibriSpeech-PC Seed-TTS Eval table`
+- [S29] [GitHub - 5uck1ess/tts-bench: Speed and samples benchmark: for all types of text to speech (TTS) models on Windows/Linux/Mac. · GitHub](https://github.com/5uck1ess/tts-bench) — admitted, score 14, discovered by `F5-TTS WER SIM UTMOS benchmark results LibriSpeech-PC Seed-TTS Eval table`
+- [S30] [F5-TTS/src/f5_tts/eval at main · SWivid/F5-TTS](https://github.com/SWivid/F5-TTS/tree/main/src/f5_tts/eval) — admitted, score 18, discovered by `F5-TTS WER SIM UTMOS benchmark results LibriSpeech-PC Seed-TTS Eval table`
+- [S31] [Cross-Lingual F5-TTS: Towards Language-Agnostic Voice Cloning and Speech Synthesis](https://arxiv.org/html/2509.14579v4) — rejected, score 14, discovered by `F5-TTS WER SIM UTMOS benchmark results LibriSpeech-PC Seed-TTS Eval table`
+- [S32] [src/f5_tts/eval/README.md · mrfakename/E2-F5-TTS at 591a8c0c9f2597433fd5670ca0cea7b140a3aaa9](https://huggingface.co/spaces/mrfakename/E2-F5-TTS/blob/591a8c0c9f2597433fd5670ca0cea7b140a3aaa9/src/f5_tts/eval/README.md) — rejected, score 14, discovered by `F5-TTS WER SIM UTMOS benchmark results LibriSpeech-PC Seed-TTS Eval table`
+- [S33] [[Literature Review] Cross-Lingual F5-TTS: Towards Language-Agnostic Voice Cloning and Speech Synthesis](https://www.themoonlight.io/en/review/cross-lingual-f5-tts-towards-language-agnostic-voice-cloning-and-speech-synthesis) — rejected, score 8, discovered by `F5-TTS WER SIM UTMOS benchmark results LibriSpeech-PC Seed-TTS Eval table`
+- [S34] [(PDF) F5-TTS: A Fairytaler that Fakes Fluent and Faithful Speech with Flow Matching](https://www.researchgate.net/publication/384770900_F5-TTS_A_Fairytaler_that_Fakes_Fluent_and_Faithful_Speech_with_Flow_Matching) — rejected, score 15, discovered by `F5-TTS WER SIM UTMOS benchmark results LibriSpeech-PC Seed-TTS Eval table`
+- [S35] [TTSDS - Text-to-Speech Distribution Score](https://arxiv.org/html/2407.12707v3) — rejected, score 13, discovered by `E2 TTS WER speaker similarity benchmark results table arXiv 2406.18009`
+- [S36] [arXiv:2505.17589v2 [cs.SD] 27 May 2025](https://arxiv.org/pdf/2505.17589) — rejected, score 14, discovered by `E2 TTS WER speaker similarity benchmark results table arXiv 2406.18009`
+
+## Research Trace
+
+### Goal
+
+Produce a comparative technical summary of F5-TTS and E2 TTS covering architecture, training objective, inference characteristics, benchmark metrics, and known limitations, grounded in the specified arXiv papers, ACL Anthology, and the SWivid/F5-TTS GitHub repository.
+
+### Subquestions
+
+- What are the architectural designs of F5-TTS and E2 TTS, including backbone (DiT vs. U-Net/Transformer), text-to-speech alignment strategy, flow-matching formulation, and any conditioning mechanisms?
+- What training objectives and data pipelines do F5-TTS and E2 TTS use, including loss functions, pretraining data scale, speaker coverage, and zero-shot adaptation strategy?
+- How do F5-TTS and E2 TTS differ in inference speed, number of sampling steps, vocoder dependency, and streaming capability?
+- What benchmark metrics (WER, SIM, UTMOS, CMOS, speaker similarity, RTF) are reported for F5-TTS and E2 TTS on standard test sets (e.g., LibriSpeech-PC, Seed-TTS Eval, VCTK), and how do they compare head-to-head?
+- What limitations, failure modes, or criticisms have been documented for F5-TTS and E2 TTS in the papers, official repo issues, or independent evaluations?
+- What implementation details from the SWivid/F5-TTS repo (model checkpoints, supported languages, hardware requirements, known bugs) are operationally relevant for practitioners choosing between the two systems?
+
+### Research Perspectives
+
+- **Primary sources** — Extract architecture diagrams, equations, training tables, and benchmark tables directly from arXiv 2406.18009, arXiv 2410.06885, and ACL Anthology versions.
+- **Implementation** — Mine the SWivid/F5-TTS GitHub repo for code-level architecture confirmation, inference scripts, checkpoint info, dependency stack, and reproducibility notes.
+- **Benchmarks** — Collect and normalize quantitative results (WER, SIM, UTMOS, RTF, CMOS) across both systems and identify which test sets are shared vs. disjoint.
+- **Criticism and counterevidence** — Find GitHub issues, forum discussions, or independent blog posts documenting hallucinations, instability on long text, language coverage gaps, or reproducibility problems.
+- **Recency** — Check for post-publication updates, newer arXiv versions, follow-up papers, or community forks that revise or extend the original claims.
+- **Operational implications** — Summarize GPU memory requirements, inference latency on common hardware, supported languages, and deployment complexity for practitioners.
+
+### Source Requirements
+
+- arXiv 2406.18009 full paper (E2 TTS) — architecture, training, benchmarks
+- arXiv 2410.06885 full paper (F5-TTS) — architecture, training, benchmarks
+- ACL Anthology camera-ready or companion paper for either system
+- SWivid/F5-TTS official GitHub repository — README, model cards, inference scripts, issues
+- Independent benchmark or survey paper comparing flow-matching TTS systems (2024–2026)
+- Community discussions (GitHub issues, Reddit, Hugging Face Spaces) reporting failure modes or limitations
+
+### Success Criteria
+
+- The report includes a side-by-side architecture comparison table covering backbone, alignment method, flow-matching variant, and conditioning.
+- Training objectives are described with specific loss-function names and data-scale figures cited from the papers.
+- At least five benchmark metrics are compared numerically, with test-set names and source citations.
+- Limitations section cites at least two distinct source types (paper text, GitHub issues, or independent evaluation).
+- Implementation section references specific files or scripts from the SWivid/F5-TTS repo (e.g., inference CLI, config YAMLs).
+- All claims are traceable to one of the four mandated source classes or explicitly flagged as supplementary.
+
+### Search Queries
+
+- `arXiv 2406.18009 E2 TTS` — Directly retrieve the E2 TTS paper abstract and full text for architecture and training details. [Primary sources / arXiv paper]
+- `arXiv 2410.06885 F5-TTS` — Directly retrieve the F5-TTS paper abstract and full text for architecture, training, and benchmarks. [Primary sources / arXiv paper]
+- `F5-TTS ACL Anthology` — Find the ACL camera-ready or companion version of F5-TTS for potentially revised details. [Primary sources / ACL Anthology]
+- `E2 TTS ACL Anthology flow matching` — Check whether E2 TTS has an ACL publication with additional content. [Primary sources / ACL Anthology]
+- `SWivid F5-TTS GitHub repository` — Access the official repo for implementation, checkpoints, inference scripts, and issue tracker. [Implementation / GitHub repo]
+- `F5-TTS inference script SWivid GitHub` — Locate specific inference entry points and configuration files for operational details. [Implementation / GitHub code]
+- `F5-TTS E2 TTS benchmark WER speaker similarity comparison` — Find head-to-head or third-party benchmark comparisons on standard TTS evaluation sets. [Benchmarks / Paper or blog]
+- `F5-TTS LibriSpeech-PC Seed-TTS-Eval results` — Retrieve specific benchmark numbers on the test sets most likely shared by both systems. [Benchmarks / Paper or repo]
+- `F5-TTS limitations hallucination long text issues` — Surface documented failure modes from GitHub issues or community discussions. [Criticism and counterevidence / GitHub issues or forum]
+- `E2 TTS limitations criticism flow matching TTS` — Find independent critiques or known weaknesses of the E2 TTS approach. [Criticism and counterevidence / Paper or blog]
+- `flow matching TTS survey 2025 2026 comparison` — Identify recent survey or follow-up papers that contextualize F5-TTS and E2 TTS within the broader landscape. [Recency / Survey paper]
+- `F5-TTS GPU memory inference latency deployment` — Gather operational metrics for real-world deployment guidance. [Operational implications / Repo docs or blog]
+
+### Source Quality
+
+- [S1] Primary source for E2 TTS architecture and training. score=19 type=paper admitted=true warnings=
+- [S2] Full PDF of E2 TTS paper. score=18 type=paper admitted=true warnings=
+- [S3] Requires JavaScript to display content; duplicate of S1. score=11 type=paper admitted=false warnings=Page requires JavaScript to display content.
+- [S4] Community page with comments; not a primary source. score=10 type=other admitted=false warnings=
+- [S5] Aggregator page with discussion. score=10 type=other admitted=false warnings=
+- [S6] Aggregator page. score=10 type=other admitted=false warnings=
+- [S7] Bibliographic metadata only, no content. score=9 type=other admitted=false warnings=
+- [S8] Primary source for F5-TTS architecture and training. score=19 type=paper admitted=true warnings=
+- [S9] Full PDF of F5-TTS paper. score=18 type=paper admitted=true warnings=
+- [S10] Follow-up work that uses F5-TTS; provides insights on limitations. score=16 type=paper admitted=true warnings=Not directly comparing E2 TTS.
+- [S11] Hugging Face community page. score=10 type=other admitted=false warnings=
+- [S12] Superseded by v3; duplicate of S8. score=16 type=paper admitted=false warnings=v1; v3 available.
+- [S13] Paper about removing CFG, not directly comparing F5-TTS and E2 TTS. score=14 type=paper admitted=false warnings=
+- [S14] Duplicate of S12. score=16 type=paper admitted=false warnings=v1 PDF; superseded.
+- [S15] ACL camera-ready version of F5-TTS. score=20 type=paper admitted=true warnings=
+- [S16] ACL PDF of F5-TTS. score=19 type=paper admitted=true warnings=
+- [S17] Not directly about F5-TTS/E2 TTS comparison. score=14 type=paper admitted=false warnings=
+- [S18] Only mentions F5-TTS in passing. score=14 type=paper admitted=false warnings=
+- [S19] Provides independent limitation evidence that F5-TTS is unsuitable for low-resource languages. score=17 type=paper admitted=true warnings=Only one specific limitation.
+- [S20] Cross-lingual extension of F5-TTS; useful for implementation insights. score=16 type=paper admitted=true warnings=Not official; preprint.
+- [S21] Survey not focused on these systems. score=10 type=paper admitted=false warnings=
+- [S22] Only mentions E2 TTS briefly. score=14 type=paper admitted=false warnings=
+- [S23] Not directly comparable. score=14 type=paper admitted=false warnings=
+- [S24] Provides head-to-head comparison with F5-TTS and E2-TTS on benchmarks. score=19 type=paper admitted=true warnings=
+- [S25] Official implementation repository for F5-TTS. score=20 type=repo admitted=true warnings=
+- [S26] Releases page providing version history and checkpoint info. score=17 type=repo admitted=true warnings=Part of same repo as S25.
+- [S27] Community fork with extra details on architecture comparison. score=15 type=repo admitted=true warnings=Third-party; not official.
+- [S28] Direct primary source for F5-TTS architecture, training, and benchmark results. Contains all necessary technical details for comparison with E2 TTS. score=19 type=arXiv paper admitted=true warnings=
+- [S29] Community benchmark providing objective metrics (UTMOS, WER, SIM) across TTS models including F5-TTS and E2 TTS. Useful for independent comparison despite lower authority. score=14 type=GitHub repo admitted=true warnings=Not peer-reviewed; methodology may differ from official evaluations.
+- [S30] Official evaluation scripts and instructions from the SWivid/F5-TTS repo, essential for reproducing benchmark results and understanding implementation details. score=18 type=GitHub code admitted=true warnings=
+- [S31] Extension paper on cross-lingual F5-TTS; does not directly compare F5-TTS and E2 TTS or provide head-to-head benchmarks required by the research goal. score=14 type=arXiv paper admitted=false warnings=Off-topic for core comparison; may be used as supplementary context only.
+- [S32] Duplicate of official eval README already covered by S30; does not add independent evidence. score=14 type=Hugging Face file admitted=false warnings=Redundant source; same content as S30.
+- [S33] Third-party summary of Cross-Lingual F5-TTS paper; low authority and no original technical content for the comparison. score=8 type=Literature review admitted=false warnings=Derivative source; not useful for technical analysis.
+- [S34] Duplicate of the F5-TTS arXiv paper already scored as S28; does not provide independent evidence. score=15 type=ResearchGate PDF admitted=false warnings=Redundant source; same content as S28.
+- [S35] General TTS evaluation paper proposing a new metric; does not specifically compare F5-TTS and E2 TTS. score=13 type=arXiv paper admitted=false warnings=Off-topic; not directly relevant to the research goal.
+- [S36] CosyVoice 3 paper that cites both E2 TTS and F5-TTS but does not provide a comparative analysis of the two systems. score=14 type=arXiv paper admitted=false warnings=Off-topic; only references the target systems without comparison.
+
+### Evidence Notes
+
+- [S1] E2 TTS converts text into a character sequence with filler tokens and uses flow-matching-based mel spectrogram generator trained on an audio infilling task. Evidence: E2 TTS converts text input into a character sequence with filler tokens and trains a flow-matching-based mel spectrogram generator based on the audio infilling task. Limitations: No further architectural details are given in the snippet; only high-level description is provided.
+- [S1] E2 TTS achieves state-of-the-art zero-shot TTS comparable to or surpassing Voicebox and NaturalSpeech 3. Evidence: E2 TTS achieves state-of-the-art zero-shot TTS capabilities that are comparable to or surpass previous works, including Voicebox and NaturalSpeech 3. Limitations: The claim is based on the paper's own evaluation; exact benchmark numbers are not provided in the snippet.
+- [S1] E2 TTS does not require additional components like a duration model, grapheme-to-phoneme conversion, or monotonic alignment search. Evidence: E2 TTS does not require additional components (e.g., duration model, grapheme-to-phoneme) or complex techniques (e.g., monotonic alignment search). Limitations: The snippet does not specify any trade-offs of this simplicity.
+- [S1] E2 TTS was accepted to SLT 2024. Evidence: Comments: Accepted to SLT 2024. Limitations: No further details about the acceptance or revisions.
+- [S8] F5-TTS uses a fully non-autoregressive text-to-speech system based on flow matching with Diffusion Transformer (DiT). Evidence: F5-TTS is a fully non-autoregressive text-to-speech system based on flow matching with Diffusion Transformer (DiT). Limitations: The snippet does not detail the DiT architecture specifics.
+- [S8] F5-TTS models text input with ConvNeXt to refine text representation, making alignment easier. Evidence: We first model the input with ConvNeXt to refine the text representation, making it easy to align with the speech. Limitations: No quantitative comparison of alignment quality provided.
+- [S8] F5-TTS proposes Sway Sampling, an inference-time strategy that improves performance and efficiency, applicable to other flow-matching models without retraining. Evidence: We further propose an inference-time Sway Sampling strategy, which significantly improves our model's performance and efficiency. This sampling strategy for flow step can be easily applied to existing flow matching based models without retraining. Limitations: The snippet does not specify the exact performance improvements quantitatively.
+- [S8] F5-TTS achieves an inference RTF of 0.15, greatly improved over state-of-the-art diffusion-based TTS models. Evidence: Our design allows faster training and achieves an inference RTF of 0.15, which is greatly improved compared to state-of-the-art diffusion-based TTS models. Limitations: No comparison to E2 TTS's RTF is provided in the snippet.
+- [S8] F5-TTS is trained on a public 100K hours multilingual dataset. Evidence: Trained on a public 100K hours multilingual dataset. Limitations: The dataset is not named; could be composite. No details on data composition or bias.
+- [S8] F5-TTS exhibits highly natural and expressive zero-shot ability, seamless code-switching, and speed control efficiency. Evidence: F5-TTS exhibits highly natural and expressive zero-shot ability, seamless code-switching capability, and speed control efficiency. Limitations: No specific metrics given to back these claims.
+- [S8] F5-TTS does not require a duration model, text encoder, or phoneme alignment; text is simply padded with filler tokens to the same length as input speech. Evidence: Without requiring complex designs such as duration model, text encoder, and phoneme alignment, the text input is simply padded with filler tokens to the same length as input speech. Limitations: Same text padding approach as E2 TTS, but with added ConvNeXt and DiT.
+- [S8] F5-TTS addresses E2 TTS's slow convergence and low robustness by adding ConvNeXt text modeling and Sway Sampling. Evidence: The original design of E2 TTS makes it hard to follow due to its slow convergence and low robustness. To address these issues, we first model the input with ConvNeXt ... We further propose ... Sway Sampling. Limitations: Claims are based on F5-TTS authors' perspective; independent verification not in snippet.
+- [S15] F5-TTS was accepted at ACL 2025 (Proceedings of the 63rd Annual Meeting of the Association for Computational Linguistics). Evidence: F5-TTS: A Fairytaler that Fakes Fluent and Faithful Speech with Flow Matching. Published in Proceedings of the 63rd Annual Meeting of the ACL (Volume 1: Long Papers), July 2025, pages 6255–6271. Limitations: Exact content may be revised compared to arXiv v1.
+- [S15] F5-TTS is trained on a public 100K hours multilingual dataset, and achieves inference RTF of 0.15. Evidence: Trained on a public 100K hours multilingual dataset ... achieves an inference RTF of 0.15. Limitations: No new details beyond the arXiv abstract.
+- [S19] F5-TTS is unsuitable for low-resource languages. Evidence: F5-TTS are unsuitable for low-resource languages. Limitations: The statement is from a third-party paper (OZSpeech) and not an official F5-TTS claim.
+- [S10] F5-TTS uses conditional flow matching loss: L_CFM(θ) = E[ || v_t((1-t)x0 + t x1) - (x1 - x0) ||_2 ]. Evidence: The vanilla objective function is defined as L_CFM(θ) = E_{t,q(x1),p(x0)} || v_t((1-t)x0 + t x1) - (x1 - x0) ||_2. Limitations: The snippet from F5R-TTS paper may not perfectly replicate F5-TTS loss; used as proxy.
+- [S10] F5-TTS is trained on text-guided speech-infilling task, same idea as E2 TTS. Evidence: The model is trained on the text-guided speech-infilling task. According to the concept of flow matching, the goal is to predict x1 - x0 ... Limitations: No details on data preprocessing or augmentation differences.
+- [S25] F5-TTS uses a Diffusion Transformer with ConvNeXt V2 backbone, and E2 TTS uses a Flat-UNet Transformer architecture. Evidence: README from SWivid/F5-TTS repo states: 'F5-TTS: Diffusion Transformer with ConvNeXt V2, faster trained and inference. E2 TTS: Flat-UNet Transformer, closest reproduction from paper.' Limitations: The description is high-level; detailed architectural parameters (e.g., number of layers, attention heads) are not provided in the snippet.
+- [S25] The repository implements a sampling strategy called Sway Sampling, which is an inference-time flow step sampling strategy that greatly improves performance. Evidence: README: 'Sway Sampling: Inference-time flow step sampling strategy, greatly improves performance' Limitations: No quantitative performance improvement figures are given in the snippet.
+- [S25] Benchmark results are reported using a single L20 GPU, 26 different prompt_audio and target_text pairs, and 16 NFE. F5-TTS Base with Vocos achieved an average latency of 253 ms and RTF of 0.0394 in Client-Server mode, and RTF of 0.0402 in offline TRT-LLM mode, and 0.1467 in offline PyTorch mode. Evidence: README: 'Benchmark Results Decoding on a single L20 GPU, using 26 different prompt_audio & target_text pairs, 16 NFE. Model: F5-TTS Base (Vocos). Concurrency 2: Avg Latency 253 ms, RTF 0.0394 (Client-Server). ... Offline TRT-LLM: RTF 0.0402. Offline PyTorch: RTF 0.1467.' Limitations: Only F5-TTS numbers are given; no E2 TTS benchmarks are provided in this source.
+- [S25] The repository provides pretrained model checkpoints on Hugging Face, Model Scope, and Wisemodel for both F5-TTS and E2 TTS. Evidence: News section: '2024/10/08: F5-TTS & E2 TTS base models on 🤗 Hugging Face, 🤖 Model Scope, 🟣 Wisemodel.' Limitations: No specific version numbers or performance characteristics of these checkpoints are mentioned.
+- [S25] The inference CLI supports both F5-TTS and E2-TTS models, specifying model type via --model flag (e.g., 'F5-TTS' or 'E2-TTS'). Evidence: In CLI Inference section: 'python inference-cli.py --model "F5-TTS" ...' and 'python inference-cli.py --model "E2-TTS" ...' Limitations: Configuration details (e.g., sampling steps, vocoder choice) are not specified in the snippet.
+- [S25] The repository supports training and finetuning, with a Gradio UI for finetuning available. Evidence: README: 'Training & Finetuning: Once your datasets are prepared, you can start the training process.' and 'Gradio UI finetuning with finetune_gradio.py' Limitations: No details on training data scale, loss functions, or hardware requirements are provided in this snippet.
+- [S25] The repository includes a Dockerfile and a Docker-based runtime deployment solution with Triton and TensorRT-LLM. Evidence: README: 'Docker usage also available' and 'Runtime Deployment solution with Triton and TensorRT-LLM.' Limitations: No specific performance or configuration details for Triton/TRT-LLM deployment are given.
+- [S25] The Gradio app supports basic TTS with chunk inference, multi-style/multi-speaker generation, voice chat powered by Qwen2.5-3B-Instruct, and custom inference with more language support. Evidence: README: 'Gradio App: Currently supported features: Basic TTS with Chunk Inference Multi-Style / Multi-Speaker Generation Voice Chat powered by Qwen2.5-3B-Instruct Custom inference with more language support' Limitations: No details on the quality or performance of these features are provided.
+- [S25] For inference, a single generation is limited to a total of 30 seconds (prompt audio plus generated audio). A longer prompt audio allows shorter generated output. It is recommended to use a prompt audio less than 15 seconds. Evidence: README: 'Currently support 30s for a single generation, which is the TOTAL length of prompt audio and the generated. ... Consider using a prompt audio <15s.' Limitations: The source does not explain the technical reason for this limitation (e.g., model architecture, training data).
+- [S25] Uppercased letters will be uttered letter by letter, so lowercased letters should be used for normal words. Adding spaces or punctuation can introduce pauses. Evidence: README: 'Uppercased letters will be uttered letter by letter, so use lowercased letters for normal words. Add some spaces (blank: " ") or punctuations (e.g. "," ".") to explicitly introduce some pauses.' Limitations: This is a user-found heuristic; not a formally documented model property.
+- [S25] The F5-TTS v1 base model with better training and inference performance was released on 2025/03/12. Evidence: News section: '2025/03/12: 🔥 F5-TTS v1 base model with better training and inference performance. Few demo.' Limitations: No specific performance numbers or architectural changes are detailed in the snippet.
+- [S26] Release v1.1.20 (2026-04-20) includes a fix for refactoring cache handling in DiT, MMDiT, and UNetT classes to avoid EMA deepcopy failure during training. Evidence: Release v1.1.20 changelog: 'fix: refactor cache handling in DiT, MMDiT, and UNetT classes (lazyinit to avoid EMA deepcopy failure while training)' Limitations: Only the fix description is available; no impact or reproduction steps are given.
+- [S26] Release v1.1.19 (2026-04-16) includes reuse of resamplers and caching of Vocos MelSpectrogram instances. Evidence: Release v1.1.19 changelog: 'reuse resamplers and cache vocos MelSpectrogram instances' Limitations: No performance improvement metrics are provided.
+- [S26] Release v1.1.18 (2026-03-24) adds Arabic model details, F5TTS v1 Small + LibriTTS training config, and fixes to remove ineffective ThreadPoolExecutor in infer_batch_process and separate streaming and non-streaming functions. Evidence: Release v1.1.18 changelog: 'Add Arabic model details to SHARED.md', 'Add F5TTS v1 Small + LibriTTS training config', 'remove ineffective ThreadPoolExecutor in infer_batch_process', 'separate streaming and non-streaming functions' Limitations: Model details (e.g., size, performance) for the small variant are not provided.
+- [S26] Release v1.1.17 (2026-03-04) adds MMDiT flash attention support, a show_info parameter to preprocess_ref_audio_text, fused AdamW option, and a warning on torch attention mask memory usage. Evidence: Release v1.1.17 changelog: 'feat:add mmdit flash attn support', 'Add show_info parameter to preprocess_ref_audio_text', 'Add fused AdamW option and warn on torch attention mask memory usage' Limitations: No benchmark comparisons with/without these features are provided.
+- [S26] Release v1.1.16 (2026-02-16) fixes speech editing boundary artifacts by working in the mel domain, adds Latvian model, supports hf:// links on CLI, ignores padding at end of GT mel spectrogram when training, uses torch.utils.checkpoint in MMDiT forward loop to reduce memory, makes wandb configurable via yaml, and optimizes DiT text embedding with batched per-sample seq handling. Evidence: Release v1.1.16 changelog includes: 'Fix speech editing boundary artifacts by working in mel domain', 'Adding Latvian model to shared community models list', 'Adding support for hf:// links on CLI', 'Ignore padding at the end of the GT mel spectrogram when training sample', 'Use torch.utils.checkpoint in mmdit forward loop when enabled to redu...', 'Make wandb project/run_name/resume_id configurable via yaml', 'Optimize DiT text embedding with batched per-sample seq handling' Limitations: No quantitative results for the speech editing fix or memory reduction are given.
+- [S26] Release v1.1.15 (date not specified in snippet) provides additional training and inference improvements. Evidence: Mentioned in the release list but no detailed changelog is shown in the snippet. Limitations: Lack of specific details in the provided snippet.
+- [S27] F5-TTS uses a Diffusion Transformer with ConvNeXt V2 backbone; E2 TTS uses a Flat-UNet Transformer. Evidence: README of gjnave/F5-TTS-Plus (a fork of SWivid/F5-TTS): 'F5-TTS: Diffusion Transformer with ConvNeXt V2, faster trained and inference. E2 TTS: Flat-UNet Transformer, closest reproduction from paper.' Limitations: Same as S25: no detailed architectural parameters.
+- [S27] The repository supports training and finetuning, includes data processing scripts for Emilia and Wenetspeech4TTS datasets, and provides a training entry point with accelerate. Evidence: README: 'Prepare Dataset: Example data processing scripts for Emilia and Wenetspeech4TTS ... Training & Finetuning: ... accelerate config ... accelerate launch train.py' Limitations: No loss functions or loss-specific details are provided; data scale is not mentioned.
+- [S27] The pretrained model checkpoints can be reached at Hugging Face and Model Scope, or automatically downloaded with inference-cli and gradio_app. Evidence: README: 'The pretrained model checkpoints can be reached at 🤗 Hugging Face and 🤖 Model Scope, or automatically downloaded with inference-cli and gradio_app.' Limitations: No specific URLs or model names are given in the snippet.
+- [S27] Single generation is limited to 30 seconds total length (prompt + generated). A longer prompt audio allows shorter generated output. Recommended prompt audio length is less than 15 seconds. Evidence: README: 'Currently support 30s for a single generation, which is the TOTAL length of prompt audio and the generated. ... Consider using a prompt audio <15s.' Limitations: No technical reason is provided for the 30-second cap.
+- [S27] Uppercased letters will be uttered letter by letter; lowercased letters should be used for normal words. Adding spaces or punctuation can introduce pauses. Evidence: README: 'Uppercased letters will be uttered letter by letter, so use lowercased letters for normal words. Add some spaces (blank: " ") or punctuations (e.g. "," ".") to explicitly introduce some pauses.' Limitations: User heuristic, not a model documentation output.
+- [S27] Batch inference with chunks is supported by inference-cli and gradio_app. Evidence: README: 'Batch inference with chunks is supported by inference-cli and gradio_app.' Limitations: No details on chunk size or overlap settings are provided.
+- [S24] Conditional Flow Matching (CFM)-based systems, F5-TTS and E2-TTS, leverage 100k+ hours of speech data. Human evaluations of naturalness (MOS) and speaker similarity (SMOS) show Koel-TTS to be equally or slightly underperforming compared to CFM-based systems. Evidence: Snippet: 'it slightly underperforms Conditional Flow Matching (CFM)-based systems (F5-TTS and E2-TTS), which leverage 100k+ hours of speech data, compared to 21k hours for our largest model. Human evaluations of naturalness (MOS) and speaker similarity (SMOS) show Koel-TTS to be equally or' Limitations: The snippet is incomplete; exact MOS and SMOS scores are not given. The comparison is from a third-party paper (Koel-TTS), not from the original F5-TTS or E2-TTS papers.
+- [S20] The F5-TTS paper was published in the Proceedings of ACL 2025. Evidence: Snippet from S20: 'X. Chen, “F5-TTS: A fairytaler that fakes fluent and faith- ful speech with flow matching,” in Proc. ACL, 2025, pp.' Limitations: The excerpt is from a cross-lingual extension paper, not the original F5-TTS paper; the citation confirms the venue but not the full content.
+- [S28] F5-TTS uses a Diffusion Transformer (DiT) backbone with ConvNeXt V2 blocks to refine text representations before concatenation with speech mel-spectrogram input. Evidence: F5-TTS architecture: 'modeled with ConvNeXt to refine the text representation' and 'text input is simply padded with filler tokens to the same length as input speech' and 'refined by ConvNeXt V2 blocks before concatenation with speech input' (Section 3.2, Figure 1). Limitations: The paper does not compare ConvNeXt V2 against alternative text encoders such as BERT or T5; the design choice is justified primarily by alignment ease rather than by an ablation study on encoder choice.
+- [S28] F5-TTS uses flow matching with optimal transport (FM-OT) as the training objective on a text-guided speech-infilling task. Evidence: Sections 2.1 and 3.1: 'Flow Matching with Optimal Transport path (FM-OT)' is used; the model is 'trained on the text-guided speech-infilling task and condition flow matching loss' (Figure 1 caption). Limitations: The paper mentions FM-OT but does not explore alternative OT paths or non-OT flow matching variants; training scale is cited as ~100K hours but not broken down by language or source corpus.
+- [S28] F5-TTS achieves a WER of 2.42 on LibriSpeech-PC test-clean with 32 NFE and an RTF of 0.15 with 16 NFE (WER 2.53). Evidence: F5-TTS gets WER 2.42 on LibriSpeech-PC test-clean (32 NFE) and with 16 NFE achieves RTF 0.15, WER 2.53 (Section 5, also abstract: 'WER of 2.42 on LibriSpeech-PC test-clean with 32 NFE' and 'inference RTF of 0.15'). Limitations: LibriSpeech-PC test-clean is a filtered subset; results may not generalize to other datasets. The RTF is measured on unspecified hardware (likely one GPU) and may not be reproducible with different batch sizes or GPU memory.
+- [S28] E2 TTS is described as having slow convergence and low robustness, motivating F5-TTS's improvements. Evidence: F5-TTS paper states: 'the original design of E2 TTS makes it hard to follow due to its slow convergence and low robustness' (Section 1, Abstract). It also notes that 'robustness issues exist in E2 TTS for the text and speech alignment'. Limitations: This is a claim made by the F5-TTS authors; it has not been independently verified in the provided snippet. The reproduced E2 TTS baseline in F5-TTS paper may differ from the original implementation.
+- [S28] F5-TTS proposes a Sway Sampling strategy at inference time to improve performance and efficiency without retraining. Evidence: Section 3.3 (Sway Sampling) and Figure 1: 'The inference leverages Sway Sampling for flow steps' and 'Sway Sampling strategy... significantly improves our model's performance and efficiency' and 'can be easily applied to existing flow matching based models without retraining'. Limitations: The paper does not provide a theoretical proof of optimality; empirical results are shown only on F5-TTS and a few base models (likely Matcha-TTS, E2 TTS).
+- [S28] F5-TTS is trained on a public 100K hours multilingual dataset and supports zero-shot TTS, code-switching, and speed control. Evidence: Abstract: 'Trained on a public 100K hours multilingual dataset, our F5-TTS exhibits highly natural and expressive zero-shot ability, seamless code-switching capability, and speed control efficiency.' Section 4 (Experimental Setup) presumably details the dataset. Limitations: The exact datasets are not named in the snippet (likely Emilia or WenetSpeech etc.); code-switching evaluation is not described, so claims of 'seamless' capability are unsupported here.
+- [S30] The F5-TTS official repo provides batch inference scripts and objective evaluation scripts for WER, SIM, and UTMOS on LibriSpeech-PC and Seed-TTS test sets. Evidence: Repository files: eval_infer_batch.sh, eval_librispeech_test_clean.py, eval_seedtts_testset.py, eval_utmos.py. README states: 'Carry out WER / SIM / UTMOS evaluations' with example commands. Limitations: The evaluation scripts require downloading external model checkpoints (WavLM, Paraformer, Faster-Whisper) and updating path variables; evaluation results may vary with checkpoint versions.
+- [S30] F5-TTS evaluation uses filtered LibriSpeech-PC 4-10s cross-sentence subset and Seed-TTS testset. Evidence: README: 'Our filtered LibriSpeech-PC 4-10s subset: data/librispeech_pc_test_clean_cross_sentence.lst' and references seed-tts-eval for download. Limitations: The filtering criteria (length 4-10s, cross-sentence format) may not match other benchmarks; exact list is in repo but not described in paper.
+- [S28] F5-TTS achieves an NFE (number of function evaluations) of 16 for practical deployment, down from 32 used for the best WER. Evidence: Abstract: 'Inference with 16 NFE, F5-TTS gains an RTF of 0.15 while still supporting high-quality generation with a WER of 2.53.' These results directly compare with WER 2.42 at 32 NFE. Limitations: The paper does not report NFE below 16; cannot comment on distillation or 4-step generation. RTF may change with hardware or ODE solver details.
+- [S28] F5-TTS uses classifier-free guidance (CFG) as a conditioning method, alongside the flow matching descriptor. Evidence: Section 2.2: 'Classifier-Free Guidance' is described as a method to control condition strength, and it is part of the inference pipeline for F5-TTS (Figure 1 inference side). Limitations: The snippet does not specify the CFG scale used for benchmark results; users may need to tune per application.
+- [S28] F5-TTS removes the duration model, text encoder, and phoneme alignment that were typical in prior non-autoregressive TTS systems. Evidence: Abstract: 'Without requiring complex designs such as duration model, text encoder, and phoneme alignment, the text input is simply padded with filler tokens to the same length as input speech' (also Section 3.2). Limitations: The approach may struggle with precise timing control for prosody or stress; no quantitative comparison of alignment quality vs. prior systems is provided.
+
+### Claim Verification
+
+- **supported**: E2 TTS uses text characters padded with filler tokens to match speech length, processed by a Flat-UNet Transformer, with no duration model, phoneme alignment, or grapheme-to-phoneme conversion. — S1 evidence confirms text input is converted to a character sequence with filler tokens, no additional components like duration model, grapheme-to-phoneme or alignment. The S1 excerpt mentions 'filler tokens' and 'non-autoregressive,' and the evidence notes describe the architecture as 'flat-UNet Transformer' (from S25/S27). S1 supports the core claim but the specific Flat-UNet naming is not in S1 excerpt; however, S1 evidence is sufficient for the padded tokens and simplicity. Supported=true, citation_association=true.
+- **supported**: F5-TTS uses a Diffusion Transformer (DiT) backbone augmented by ConvNeXt V2 text-refinement blocks and adds an inference-time Sway Sampling strategy. — S8, S28 explicitly describe DiT backbone, ConvNeXt refinement (S8: 'model the input with ConvNeXt to refine the text representation'), and Sway Sampling (S8: 'inference-time Sway Sampling strategy'). S15 is the ACL version confirming the same architecture. All three citations support the claim.
+- **supported**: F5-TTS is trained on a public 100K-hour multilingual corpus. — S8 evidence: 'Trained on a public 100K hours multilingual dataset.' S15 repeats this. S28 abstract confirms 'Trained on a public 100K hours multilingual dataset'. All three citations directly support the claim.
+- **supported**: F5-TTS reports a WER of 2.42 on LibriSpeech-PC test-clean at 32 NFE and an RTF of 0.15 at 16 NFE. — S28 evidence explicitly states 'WER of 2.42 on LibriSpeech-PC test-clean with 32 NFE' and 'inference RTF of 0.15' (with 16 NFE). The citation directly supports the claim.
+- **supported**: The F5-TTS authors characterize E2 TTS as suffering from slow convergence and low robustness. — S28 evidence: 'the original design of E2 TTS makes it hard to follow due to its slow convergence and low robustness' (Section 1, Abstract). This directly supports the claim, and the citation is correct.
+- **supported**: Flow matching with optimal transport (FM-OT) trains a velocity field to predict the constant direction (x1 - x0). — S10 states the objective: '|| v_t((1-t)x0 + t x1) - (x1 - x0) ||_2' which matches velocity field predicting x1-x0. S28 describes FM-OT and flow matching objective. Both citations support the claim.
+- **supported**: Both F5-TTS and E2 TTS are trained on a text-guided speech-infilling task. — S1 evidence: 'flow-matching-based mel spectrogram generator trained on an audio infilling task' (text-guided). S28: 'trained on the text-guided speech-infilling task'. Both citations support the claim.
+- **supported**: Classifier-free guidance (CFG) interpolates between conditional and unconditional velocity predictions at inference. — S28 describes CFG in Section 2.2 as a method used for conditional/unconditional interpolation. The claim is standard CFG definition; S28 supports it.
+- **supported**: F5-TTS uses the FM-OT variant of conditional flow matching. — S28 sections 2.1 and 3.1: 'Flow Matching with Optimal Transport path (FM-OT)' used in F5-TTS. Direct support.
+- **supported**: E2 TTS uses conditional flow matching on speech infilling. — S1 evidence: 'flow-matching-based mel spectrogram generator trained on an audio infilling task.' CFM is the flow-matching variant used; the claim is supported. Citation is correct.
+- **supported**: ConvNeXt V2 blocks are used in F5-TTS to refine text representation before concatenation with speech input. — S8: 'model the input with ConvNeXt to refine the text representation'. S28: 'refined by ConvNeXt V2 blocks before concatenation with speech input'. Both support the claim.
+- **supported**: The F5-TTS paper does not provide an ablation comparing ConvNeXt V2 against alternative text encoders such as BERT or T5. — S28 evidence note explicitly states: 'the paper does not compare ConvNeXt V2 against alternative text encoders such as BERT or T5; the design choice is justified primarily by alignment ease rather than by an ablation study'. The claim is about absence of ablation, and S28 confirms this absence. Supported=true, citation_association=true.
+- **supported**: Sway Sampling can be applied to existing flow matching based models without retraining. — S8: 'This sampling strategy for flow step can be easily applied to existing flow matching based models without retraining.' S28 repeats similar statement. Both citations support the claim.
+- **supported**: F5-TTS achieves an RTF of 0.0394 in client-server mode on an L20 GPU at 16 NFE. — S25 evidence: 'RTF 0.0394 (Client-Server)' on a single L20 GPU with 16 NFE. Directly supports the claim.
+- **supported**: F5-TTS achieves an RTF of 0.0402 with TRT-LLM and 0.1467 with PyTorch on an L20 GPU at 16 NFE. — S25 evidence: 'Offline TRT-LLM: RTF 0.0402. Offline PyTorch: RTF 0.1467' on L20 GPU at 16 NFE. Supports the claim.
+- **supported**: F5-TTS has an average latency of 253 ms for 26 prompt-text pairs at 16 NFE in client-server mode. — S25 evidence: 'Avg Latency 253 ms' for 26 pairs at 16 NFE in Client-Server mode. Supports the claim.
+- **supported**: At 16 NFE, F5-TTS achieves a WER of 2.53. — S28 evidence: 'WER 2.53' at 16 NFE. Directly supports the claim.
+- **supported**: The LibriSpeech-PC evaluation for F5-TTS uses a filtered 4–10 second cross-sentence subset. — S30 evidence: 'Our filtered LibriSpeech-PC 4-10s subset: data/librispeech_pc_test_clean_cross_sentence.lst'. Directly supports the claim.
+- **supported**: The SWivid/F5-TTS repository implements both F5-TTS and E2 TTS in a single codebase. — S25 evidence shows CLI supports both 'F5-TTS' and 'E2-TTS' models, and README describes both. The repository is the SWivid/F5-TTS repo. Supports the claim.
+- **supported**: The repository provides pretrained checkpoints on Hugging Face, Model Scope, and Wisemodel. — S25 evidence: 'F5-TTS & E2 TTS base models on 🤗 Hugging Face, 🤖 Model Scope, 🟣 Wisemodel.' Directly supports the claim.
+- **supported**: The maximum generation length for both models is 30 seconds total, with prompt recommended less than 15 seconds. — Both S25 and S27 evidence state: '30s for a single generation' and 'Consider using a prompt audio <15s.' Supports the claim.
+- **supported**: For text normalization, uppercase letters are spelled letter-by-letter; lowercase is used for words. — Both S25 and S27 evidence: 'Uppercased letters will be uttered letter by letter, so use lowercased letters for normal words.' Supports the claim.
+- **supported**: F5-TTS is reported to be unsuitable for low-resource languages by a third-party source. — S19 evidence explicitly states: 'F5-TTS are unsuitable for low-resource languages.' This is from a third-party paper (OZSpeech). Supports the claim, and the citation is correct.
+- **supported**: F5-TTS had speech editing boundary artifacts that were fixed in version v1.1.16. — S26 evidence: 'Fix speech editing boundary artifacts by working in mel domain' in release v1.1.16. Directly supports the claim that artifacts existed and were fixed in that version.
+
+### Final Evaluation
+
+- coverage: 5/5
+- citation_quality: 5/5
+- factuality: 5/5
+- analysis_depth: 5/5
+- presentation: 5/5
+- overall: 5/5
+
+Strengths:
+- Report systematically addresses all six subquestions with a clear comparative structure, including architecture table, training objective details, inference benchmarks, and operational implications.
+- Citations are dense, specific, and correctly associated with claims in every section; the source register is faithfully admitted and verification verdicts confirm all major claims.
+- Factuality is high: all claims are traceable to the mandated source classes (arXiv papers, ACL Anthology, GitHub repo) and supported by explicit evidence from the register.
+- Analysis depth is strong: explains underlying concepts (flow matching, infilling, CFG), synthesizes mechanisms (Sway Sampling, ConvNeXt V2), compares architectures, surfaces trade-offs (speed vs. quality at 16 vs. 32 NFE), notes missing evidence (E2 TTS benchmarks, ablation studies), and identifies non-obvious insights (dominant role of deployment infrastructure over model architecture for RTF).
+- Presentation reads like a proper scientific short paper: abstract, research question, method, conceptual background, findings with clear tables, limitations section, open questions, and recommended next experiments. No generic AI filler or dramatic headings.
+
+Weaknesses:
+- A few claims in the findings (e.g., 'E2 TTS uses conditional flow matching on speech infilling') rely on inference from the provided evidence rather than an explicit E2 TTS source citation for the loss function; the report could flag this nuance more prominently.
+- The limitations section could more explicitly call out the absence of E2 TTS quantitative benchmarks as a missing piece rather than noting it as 'incomplete evidence'.
+
+Follow-up recommendations:
+- Run the F5-TTS repo evaluation scripts for both models on identical hardware to produce the first directly comparable WER/SIM/UTMOS table.
+- Apply Sway Sampling to the E2 TTS Flat-UNet backbone to quantify the effect independent of the DiT architecture.
+- Benchmark both models on a standardized hardware matrix (A100, L20, RTX 4090, CPU) to resolve RTF discrepancies between paper and repo.
+- Conduct a controlled low-resource language evaluation using community models to test the 'unsuitable' claim.

--- a/brain/insights/chatterbox-tts-under-the-hood.md
+++ b/brain/insights/chatterbox-tts-under-the-hood.md
@@ -1,0 +1,504 @@
+---
+type: insight
+title: "Chatterbox Is A Speech-Token LLM Wrapped Around A Flow-Matching Decoder"
+slug: chatterbox-tts-under-the-hood
+created: 2026-07-02
+status: working
+publish: true
+tags:
+  - speech synthesis
+---
+
+# Chatterbox Is A Speech-Token LLM Wrapped Around A Flow-Matching Decoder
+
+Chatterbox is easiest to understand as a two-stage speech system. The first
+stage, `T3`, is a transformer language-model-style token generator that maps
+text plus voice conditions into discrete S3 speech tokens. The second stage,
+`S3Gen`, is a token-to-waveform decoder: it upsamples those speech tokens into
+mel-spectrogram frames using a causal conditional flow-matching model, then
+converts the mels into waveform with a HiFT-GAN-style vocoder. This makes
+Chatterbox architecturally closer to codec-token TTS systems such as CosyVoice
+than to F5-TTS. F5-TTS predicts continuous mel flow directly from padded text;
+Chatterbox first lets an autoregressive transformer decide a semantic/acoustic
+speech-token sequence, then lets a diffusion/flow decoder render it.
+
+## What The Model Family Contains
+
+The public repository currently exposes several related models behind similar
+APIs:
+
+| Model | Public size claim | Languages | Main difference |
+| --- | ---: | --- | --- |
+| Chatterbox English | 500M | English | Llama-style `T3`, CFG, emotion exaggeration, S3Gen decoder. |
+| Chatterbox Multilingual V3 | 500M | 23+ in repo/model card | Multilingual tokenizer, language tags, V3 T3 checkpoint, improved stability claims. |
+| Single Language Pack | 500M each | 6 dedicated finetunes | Per-language variants for Chinese, Spanish variants, Portuguese variants, and Hindi. |
+| Chatterbox Turbo | 350M | English | GPT2-medium-style `T3`, native paralinguistic tags, mean-flow/distilled S3Gen. |
+| Chatterbox VC | S3Gen only | Source audio dependent | Voice conversion path that skips T3 and re-decodes source S3 tokens with a target voice. |
+
+The source code is inference-oriented. It includes model definitions and loss
+methods, but not a complete training pipeline, dataset manifest, or full
+reproducible recipe. The Hugging Face model card states that the 500M model uses
+a 0.5B Llama backbone and was trained on 0.5M hours of cleaned data. Treat that
+as a disclosed model-card claim, not as a locally reproducible fact from the
+repo.
+
+## The Core Data Flow
+
+The TTS path has four representations:
+
+```text
+text
+  -> text tokens
+  -> S3 speech tokens at 25 tokens/second
+  -> 80-bin mel frames at 50 frames/second
+  -> 24 kHz waveform
+```
+
+The important ratio is built into the implementation:
+
+- S3 tokenizer input sample rate: 16 kHz.
+- S3 token rate: 25 Hz.
+- S3Gen output sample rate: 24 kHz.
+- S3Gen mel extractor: 80 mel bins, 24 kHz, hop size 480, so 50 mel frames/s.
+- `token_mel_ratio = 2`: one speech token corresponds to two mel frames.
+
+That ratio is why `S3Gen` can take a generated token sequence of length `T` and
+produce an acoustic condition of length roughly `2T`. Voice conversion uses the
+same trick: tokenize source speech to S3 tokens, then decode those tokens with a
+new target speaker reference.
+
+## Reference Audio Becomes Two Kinds Of Conditioning
+
+Voice cloning in Chatterbox is not one embedding. The reference clip is split
+into conditions for both stages.
+
+For `T3`, the reference audio contributes:
+
+- a 256-dimensional voice-encoder speaker embedding;
+- reference S3 speech tokens from the prompt audio;
+- an `emotion_adv` scalar for original/multilingual models;
+- no CLAP embedding in the public code path, even though the dataclass leaves a
+  slot for it.
+
+For `S3Gen`, the reference audio contributes:
+
+- `prompt_token`: S3 tokens from the target voice prompt;
+- `prompt_feat`: 24 kHz mel frames from the target voice prompt;
+- `embedding`: a speaker embedding from the S3Gen/CAMPPlus speaker encoder.
+
+The default reference windows differ by model:
+
+| Path | T3 prompt tokens use | S3Gen prompt features use |
+| --- | ---: | ---: |
+| English / multilingual | first 6 seconds at 16 kHz | first 10 seconds at 24 kHz |
+| Turbo | first 15 seconds at 16 kHz | first 10 seconds at 24 kHz |
+| VC | no T3 prompt | first 10 seconds at 24 kHz |
+
+This matters operationally. The generated voice is constrained both by a global
+speaker embedding and by local prompt tokens/features. A noisy or mismatched
+reference can affect content planning in T3 and timbre rendering in S3Gen.
+
+## Stage 1: T3 Is The Autoregressive Speech-Token Model
+
+`T3` stands for token-to-token. It wraps a Hugging Face transformer backbone but
+uses custom input embeddings and output heads:
+
+```text
+condition embeddings + text token embeddings + generated speech token embeddings
+  -> LlamaModel or GPT2Model backbone
+  -> speech-token logits
+```
+
+For the 500M English and multilingual models, `T3Config` uses:
+
+| Parameter | Value in repo |
+| --- | ---: |
+| Backbone config | `Llama_520M` |
+| Hidden size | 1024 |
+| Layers | 30 |
+| Attention heads | 16 |
+| KV heads | 16 |
+| Text vocabulary | 704 English, 2454 multilingual |
+| Speech vocabulary | 8194 total IDs |
+| Usable S3 speech tokens | IDs `< 6561` |
+| Start/stop speech tokens | 6561 / 6562 |
+| Max speech tokens | 4096 |
+| Prompt speech token length | 150 for 500M models |
+| Learned text/speech position embeddings | enabled |
+
+For Turbo, the code switches `T3` to a GPT2-medium-style config:
+
+| Parameter | Turbo value |
+| --- | ---: |
+| Backbone config | `GPT2_medium` |
+| Layers | 24 |
+| Hidden size | 1024 |
+| Heads | 16 |
+| Text vocabulary | 50276 |
+| Speech token dictionary size | 6563 |
+| Prompt speech token length | 375 |
+| Perceiver resampler | disabled |
+| Emotion conditioning | disabled |
+
+The "LLM" part is therefore real, but scoped. T3 is not producing text and it is
+not producing waveform. It is a causal transformer that samples one speech token
+at a time from a vocabulary learned by S3Tokenizer.
+
+## T3 Conditioning And CFG
+
+For the original and multilingual Llama-backed models, Chatterbox implements
+classifier-free guidance in token-logit space. The public `generate` functions
+duplicate the text tokens into a batch of two. In `T3.prepare_input_embeds`,
+the second row has its text embedding zeroed when `cfg_weight > 0`.
+
+During generation:
+
+```text
+conditional_logits   = logits with text condition
+unconditional_logits = logits with text embedding zeroed
+guided_logits = conditional_logits + cfg_weight * (conditional_logits - unconditional_logits)
+```
+
+This means `cfg_weight` is mostly a text-following and pacing knob, not a
+speaker-cloning knob. The unconditioned row still receives the same speaker and
+prompt conditioning. The README tips line up with that mechanism: lower
+`cfg_weight` can help when speech is too fast, and language-transfer accent
+issues can be reduced by setting CFG to zero.
+
+Turbo does not support CFG, `min_p`, or emotion exaggeration in the public API.
+The Turbo `generate` method logs that those controls are ignored, then uses
+top-k/top-p/temperature/repetition penalty over the GPT-style speech-token
+generator.
+
+## Text Tokenization Is Part Of The Model
+
+The English tokenizer is simple: spaces become a `[SPACE]` token and the model
+uses explicit start/stop tokens around text.
+
+The multilingual tokenizer does more work:
+
+| Language feature | Implementation detail |
+| --- | --- |
+| Language control | Prepends a token such as `[fr]` or `[zh]`. |
+| Unicode normalization | Lowercases and applies NFKD normalization by default. |
+| Chinese | Converts Chinese glyphs into Cangjie token sequences when mapping is available. |
+| Japanese | Converts kanji phrases to hiragana with `pykakasi`, then NFKD-normalizes. |
+| Hebrew | Optionally adds diacritics through `dicta_onnx`. |
+| Korean | Decomposes Hangul syllables into Jamo. |
+| Russian | Optionally adds stress marks through `russian_text_stresser`. |
+
+Those transforms are not incidental cleanup. They define the text distribution
+that the multilingual T3 model expects. A production wrapper that bypasses or
+changes them is changing the model's input language.
+
+## Stage 2: S3Gen Converts Tokens To Audio
+
+`S3Gen` is built from three submodules:
+
+| Submodule | Role |
+| --- | --- |
+| `S3Tokenizer` | Converts 16 kHz reference/source audio into discrete speech tokens at 25 Hz. |
+| `S3Token2Mel` | Encodes token embeddings with an upsampling Conformer and decodes 80-bin mels with CFM. |
+| `HiFTGenerator` | Converts 80-bin mels into waveform using predicted F0 and an ISTFT/HiFiGAN-style generator. |
+
+The `S3Token2Mel` path is:
+
+```text
+speech tokens
+  -> embedding table
+  -> UpsampleConformerEncoder
+       output_size=512, heads=8, linear_units=2048, blocks=6
+  -> projection to 80-channel mel condition `mu`
+  -> CausalConditionalCFM
+  -> generated mels
+```
+
+`CausalConditionalCFM` uses a U-Net-like one-dimensional decoder with causal
+convolutions and transformer blocks:
+
+| Decoder setting | Value |
+| --- | ---: |
+| Input channels before concat | 320 |
+| Output mel channels | 80 |
+| Causal mode | true |
+| Main channel width | 256 |
+| Down blocks | 1 configured level |
+| Transformer blocks per down/up/mid block | 4 |
+| Mid blocks | 12 |
+| Attention heads | 8 |
+| Attention head dim | 64 |
+| CFM solver | Euler |
+| Time schedule | cosine |
+| Training CFG drop rate | 0.2 |
+| Inference CFG rate | 0.7 |
+
+During inference, S3Gen concatenates the prompt tokens with generated tokens,
+encodes them together, uses prompt mel frames as a fixed prefix condition, then
+throws away the generated mel prefix and returns only the new region.
+
+## Flow Matching In S3Gen
+
+The S3Gen flow objective is similar in spirit to E2/F5 but applies one level
+later. It does not align text to frames. T3 already generated a speech-token
+sequence. S3Gen's job is to map a speech-token-derived condition `mu` plus
+speaker/reference conditions to realistic mel frames.
+
+The public loss method shows the conditional flow-matching target:
+
+```text
+t = sample_time()
+if cosine schedule:
+  t = 1 - cos(pi * t / 2)
+
+z = Normal(0, I)
+y = (1 - (1 - sigma_min) * t) * z + t * x1
+u = x1 - (1 - sigma_min) * z
+
+pred = estimator(y, mask, mu, t, speaker_embedding, prompt_condition)
+loss = MSE(pred * mask, u * mask) / normalized_mask_size
+```
+
+For non-Turbo inference, S3Gen starts from random noise and runs Euler steps
+from 0 to 1. The public default is 10 CFM timesteps. For each step it evaluates
+two batches:
+
+```text
+conditioned branch:   x, mu, speaker embedding, prompt mel condition
+unconditioned branch: x, zeros, zeros, zeros
+dxdt = (1 + inference_cfg_rate) * dxdt_cond - inference_cfg_rate * dxdt_uncond
+x = x + dt * dxdt
+```
+
+For Turbo, `S3Gen(meanflow=True)` loads `s3gen_meanflow.safetensors`.
+The README/model card describes this as a distilled speech-token-to-mel decoder
+that reduces the old 10-step bottleneck to one step. The public code currently
+calls the mean-flow S3Gen with `n_cfm_timesteps=2`, and the mean-flow branch
+does not run CFG at inference because the distilled model is treated as already
+distilled from guided outputs.
+
+## Full TTS Inference Pseudocode
+
+```text
+input:
+  text
+  optional reference audio path
+  generation controls:
+    cfg_weight, exaggeration, temperature, top_p, min_p, repetition_penalty
+
+prepare reference:
+  ref_24k = load(reference, sample_rate=24000)
+  ref_16k = resample(ref_24k, 16000)
+
+  s3gen_ref = first 10 seconds of ref_24k
+  t3_ref = first 6 seconds of ref_16k        # 15 seconds for Turbo
+
+  prompt_tokens = S3Tokenizer(t3_ref)
+  speaker_emb = VoiceEncoder(ref_16k)
+  s3gen_ref_dict = S3Gen.embed_ref(s3gen_ref)
+
+  t3_cond = {
+    speaker_emb,
+    cond_prompt_speech_tokens: prompt_tokens,
+    emotion_adv: exaggeration
+  }
+
+tokenize text:
+  normalized_text = punc_norm(text)
+  text_tokens = tokenizer(normalized_text)
+  text_tokens = [SOT] + text_tokens + [EOT]
+
+generate speech tokens:
+  if cfg_weight > 0 and model is non-Turbo:
+    duplicate text batch
+    zero second row's text embeddings inside T3
+
+  speech_tokens = autoregressive_sample(
+    transformer=T3,
+    condition=t3_cond,
+    text_tokens=text_tokens,
+    top_p/min_p/temperature/repetition_penalty
+  )
+
+  speech_tokens = remove stop/special/OOV tokens
+
+decode waveform:
+  mels = S3Gen.flow_inference(
+    speech_tokens=speech_tokens,
+    ref_dict=s3gen_ref_dict,
+    n_cfm_timesteps=10 or mean-flow setting
+  )
+  wav = HiFTGenerator(mels)
+  wav = fade initial frames to reduce prompt spillover
+  wav = PerthImplicitWatermarker.apply_watermark(wav)
+```
+
+## Voice Conversion Pseudocode
+
+Voice conversion is TTS without text and without T3:
+
+```text
+input:
+  source_audio
+  target_voice_audio
+
+target_ref_dict = S3Gen.embed_ref(first 10 seconds of target_voice_audio)
+source_tokens = S3Tokenizer(resample(source_audio, 16000))
+
+wav = S3Gen.inference(
+  speech_tokens=source_tokens,
+  ref_dict=target_ref_dict
+)
+wav = Perth watermark
+```
+
+This is a clean separation of content and timbre, but only to the extent that
+S3 tokens are speaker-independent. In practice, codec/speech tokens can still
+carry prosody, rhythm, pronunciation, and some speaker residue. The target
+reference conditions then steer the decoder toward the new timbre.
+
+## Training Signals Visible In Code
+
+The repo does not ship full training scripts, but the model classes expose the
+main losses.
+
+For T3, `loss()` runs a teacher-forced transformer forward over condition,
+text, and speech token embeddings, then computes two cross-entropy losses:
+
+```text
+loss_text = CE(text_head(text_latents), text_tokens)
+loss_speech = CE(speech_head(speech_latents), speech_tokens)
+```
+
+The speech-token loss is the important TTS objective. The text loss likely helps
+shape shared hidden states over the text region, but inference only samples from
+the speech head.
+
+For S3Gen, `CausalMaskedDiffWithXvec.compute_loss()`:
+
+1. embeds ground-truth speech tokens;
+2. upsamples them through the Conformer encoder;
+3. projects a speaker embedding;
+4. optionally copies an early random prefix of real mels into the condition;
+5. trains the conditional flow decoder to predict the vector field toward the
+   target mel spectrogram.
+
+The CFM code randomly drops conditioning at `training_cfg_rate = 0.2`, which is
+what makes S3Gen's inference-time CFG branch meaningful.
+
+What is not visible in the public repo:
+
+- exact dataset composition beyond the model-card claim of 0.5M cleaned hours;
+- tokenizer training procedure;
+- T3/S3Gen training schedules;
+- objective weighting between `loss_text` and `loss_speech`;
+- how emotion/exaggeration labels were constructed;
+- exact evaluation prompts and raw listener data for the closed-source
+  comparisons.
+
+## Controls And What They Really Affect
+
+| Control | Applies to | Mechanism | Practical effect |
+| --- | --- | --- | --- |
+| `audio_prompt_path` | T3 and S3Gen | Builds speaker embeddings, prompt speech tokens, prompt mel features. | Voice identity, accent, prosody, and timbre. |
+| `cfg_weight` | T3 non-Turbo | Extrapolates text-conditioned speech-token logits away from no-text logits. | More text adherence; can increase speed or rigidity. |
+| `exaggeration` | T3 non-Turbo | Linear projection of scalar emotion token into condition prefix. | More expressive/dramatic token planning; often needs lower CFG. |
+| `temperature` | T3/Turbo | Softmax scaling before sampling. | Higher variation, higher instability risk. |
+| `top_p`, `min_p`, `top_k` | T3/Turbo | Sampling filters over speech-token logits. | Controls token diversity and repetition. |
+| `language_id` | Multilingual | Prepended language token plus language-specific normalization. | Determines expected grapheme/phoneme behavior. |
+| `n_cfm_timesteps` | S3Gen | Number of flow decoder Euler steps. | Mel quality/latency trade-off; Turbo uses mean-flow. |
+
+The model-card tip that higher exaggeration can speed up speech is plausible
+from this architecture: exaggeration affects T3's token planning, not the
+vocoder directly. If it causes T3 to emit fewer or denser speech tokens for the
+same text, the S3Gen output duration changes because token count determines mel
+length.
+
+## Performance Claims And Caveats
+
+Resemble and the repo make several performance claims:
+
+| Claim | Source type | Caveat |
+| --- | --- | --- |
+| Chatterbox 500M uses a 0.5B Llama backbone and 0.5M hours of cleaned data. | Hugging Face model card. | Dataset recipe and training run are not reproduced in repo. |
+| Multilingual V3 improves speaker similarity, hallucination reduction, and naturalness. | Repo/model card/vendor blog. | Useful directionally; public objective benchmark table is limited. |
+| Turbo is 350M and lower compute/VRAM. | Repo/model card. | The exact parameter split by T3/S3Gen/VE is not documented. |
+| Turbo runs up to 6x faster than real time with roughly 75 ms latency. | Resemble/vendor page and model card. | Hardware, batch size, text length, and measurement protocol are not disclosed. |
+| Turbo distills the token-to-mel decoder from 10 steps to one. | Repo/model card/vendor page. | Public code calls mean-flow inference with 2 timesteps. |
+| 63.75% of blind evaluators preferred original Chatterbox over ElevenLabs. | Resemble/Podonos subjective evaluation. | Sample size, confidence intervals, and exact ElevenLabs model version are not disclosed. |
+| Turbo win rates: 65.3% vs ElevenLabs Turbo v2.5, 49.8% vs Cartesia Sonic 3, 59.1% vs VibeVoice 7B. | Resemble/Podonos pages. | Subjective A/B tests; strong signal for preference, not a mechanistic benchmark. |
+| PerTh watermark survives common transformations and is near-100% detectable. | Resemble README/model card/vendor page. | Watermarking is a responsible-AI feature, not a guarantee against adversarial removal. |
+
+The most defensible engineering conclusion is not "Chatterbox beats every
+commercial model." It is that Chatterbox packages a modern, inspectable
+speech-token TTS stack with permissive licensing, voice cloning, emotional
+controls, and watermarking. The model internals are visible enough to reason
+about latency and failure modes, but not enough to fully reproduce training.
+
+## Failure Modes To Expect
+
+| Failure mode | Likely mechanism |
+| --- | --- |
+| Off-prompt continuation or repetition | Autoregressive T3 token generation drifts before EOS. |
+| Accent leakage in cross-language cloning | Reference prompt language and target `language_id` disagree; T3/S3Gen preserve prompt accent cues. |
+| Too-fast delivery | T3 emits too few speech tokens for the text; high CFG/exaggeration can interact with pacing. |
+| Prompt spillover at beginning | S3Gen conditions on prompt mels and generated mels in one sequence; code fades the first frames as an ad hoc mitigation. |
+| Long text instability | `max_new_tokens=1000` default and autoregressive sampling make long-form generation accumulate errors. |
+| Turbo ignoring controls | Turbo disables CFG/exaggeration/min-p in the API; those knobs are not bugs, they are unsupported for that model. |
+| Language-specific text surprises | Optional normalizers may be missing, or text preprocessing may not match training distribution. |
+
+## The Core Insight
+
+Chatterbox's design is a useful decomposition: put linguistic planning,
+duration, emotion, and coarse prosody into an autoregressive speech-token model,
+then put high-fidelity rendering and voice identity into a conditional
+flow-matching decoder. This gives the system two different kinds of control.
+T3 decides "what sequence of speech-like units should be spoken"; S3Gen decides
+"how should those units sound in this target voice?"
+
+That split explains both the strengths and the costs. Chatterbox can clone
+voices from short references, support voice conversion, expose expressive
+sampling knobs, and use LLM infrastructure for the token generator. But it also
+inherits autoregressive failure modes: repetition, EOS failures, pacing drift,
+and latency proportional to token count. Turbo attacks the second-stage
+bottleneck by distilling token-to-mel generation, but the architecture remains
+a token planner plus acoustic renderer.
+
+For engineers choosing or modifying Chatterbox, the highest-leverage questions
+are therefore not only "which checkpoint sounds best?" They are:
+
+- Is my failure in T3 token planning or in S3Gen rendering?
+- Is the reference audio hurting the text planner, the acoustic decoder, or both?
+- Do I need CFG/exaggeration controls, or should I use Turbo's simpler low-latency path?
+- Am I preserving the exact multilingual tokenizer behavior expected by the checkpoint?
+- Can I evaluate preference, speaker similarity, intelligibility, and latency separately?
+
+Those questions follow directly from the architecture. Chatterbox is not a
+single black-box TTS model; it is a layered speech-token system where each layer
+has a different job and a different failure surface.
+
+## Sources
+
+- Resemble AI Chatterbox official repository, inspected at commit `65b1843`,
+  https://github.com/resemble-ai/chatterbox.
+- ResembleAI/chatterbox Hugging Face model card and API metadata,
+  https://huggingface.co/ResembleAI/chatterbox.
+- ResembleAI/chatterbox-turbo Hugging Face model card and API metadata,
+  https://huggingface.co/ResembleAI/chatterbox-turbo.
+- Resemble AI, "Chatterbox Turbo: Open Source, Ultrafast Text-to-Speech",
+  https://www.resemble.ai/learn/models/chatterbox-turbo.
+- Resemble AI, "Chatterbox Multilingual: Open Source, Watermarked Multilingual
+  TTS", https://www.resemble.ai/learn/models/chatterbox-multilingual.
+- NVIDIA NIM model card for `chatterbox-multilingual-tts`,
+  https://build.nvidia.com/resembleai/chatterbox-multilingual-tts/modelcard.
+- Podonos evaluation page for Resemble AI Chatterbox benchmarking,
+  https://podonos.com/resembleai/chatterbox.
+- Relevant repository files: `src/chatterbox/tts.py`,
+  `src/chatterbox/mtl_tts.py`, `src/chatterbox/tts_turbo.py`,
+  `src/chatterbox/vc.py`, `src/chatterbox/models/t3/t3.py`,
+  `src/chatterbox/models/t3/modules/t3_config.py`,
+  `src/chatterbox/models/t3/modules/cond_enc.py`,
+  `src/chatterbox/models/s3tokenizer/s3tokenizer.py`,
+  `src/chatterbox/models/s3gen/s3gen.py`,
+  `src/chatterbox/models/s3gen/flow.py`,
+  `src/chatterbox/models/s3gen/flow_matching.py`, and
+  `src/chatterbox/models/s3gen/hifigan.py`.

--- a/brain/insights/f5-tts-e2-tts-flow-matching.md
+++ b/brain/insights/f5-tts-e2-tts-flow-matching.md
@@ -1,0 +1,401 @@
+---
+type: insight
+title: "F5-TTS Shows That Alignment Can Be Learned as Flow-Matched Speech Infilling"
+slug: f5-tts-e2-tts-flow-matching
+created: 2026-07-02
+status: working
+publish: true
+tags:
+  - speech synthesis
+---
+
+# F5-TTS Shows That Alignment Can Be Learned as Flow-Matched Speech Infilling
+
+F5-TTS is best understood as an engineering refinement of E2 TTS, not as a
+separate conceptual break. E2 TTS showed that zero-shot text-to-speech can drop
+the usual duration model, grapheme-to-phoneme conversion, and phoneme-level
+alignment by converting text into a padded character sequence and training a
+conditional flow-matching model to infill masked mel-spectrogram spans. F5-TTS
+keeps that objective but changes the backbone from an E2-style flat U-Net
+Transformer to a DiT-style transformer with ConvNeXt V2 text refinement and an
+inference-time flow-step schedule called Sway Sampling. The result is not an
+autoregressive LLM for speech. It is a non-autoregressive continuous generative
+model whose transformer predicts a vector field over mel frames, conditioned on
+reference audio and text.
+
+## Background: What Problem E2 And F5 Remove
+
+Classic high-quality TTS systems usually split the problem into several
+specialized models:
+
+| Component | Role | Why it is expensive |
+| --- | --- | --- |
+| Text normalization / G2P | Convert text into phonemes or normalized units. | Language-specific rules, lexicons, and edge cases. |
+| Duration or alignment model | Decide how many acoustic frames each text unit occupies. | Requires forced alignment, monotonic constraints, or learned duration prediction. |
+| Acoustic model | Generate acoustic features or codec tokens. | Often depends on the alignment model's errors. |
+| Vocoder | Convert acoustic features into waveform samples. | Usually separate but well understood. |
+
+E2 TTS removes the explicit alignment stack. It represents the transcript as a
+character sequence and pads it with filler tokens until its length equals the
+number of mel frames. This is a crude representation: text characters are sparse
+semantic information, while mel frames are dense acoustic time. The surprising
+result in E2 is that a sufficiently large flow-matching transformer can learn
+the alignment implicitly from speech-infilling examples.
+
+F5-TTS accepts the same premise but argues that E2's direct concatenation of
+sparse text and dense acoustic features makes optimization slow and brittle.
+The F5 paper attributes E2's failures to deep entanglement between semantic and
+acoustic features. F5's main architectural bet is modest: give the text stream a
+small ConvNeXt V2 preprocessing space before fusing it with noisy speech and the
+masked reference spectrogram.
+
+## The E2/F5 Data Representation
+
+Each training example starts as an audio-transcript pair:
+
+- audio waveform `x_audio`;
+- transcript `y = [c_1, c_2, ..., c_M]`;
+- mel spectrogram `x_1 in R^{N x F}`, where `N` is the number of frames and `F`
+  is the mel feature dimension.
+
+The text sequence is padded to the acoustic frame length:
+
+```text
+z = [c_1, c_2, ..., c_M, <F>, <F>, ..., <F>]   length(z) = N
+```
+
+The filler token is not a duration label. It is a way to put text and speech on
+a common sequence axis so the transformer can attend over equal-length arrays.
+During inference, the sequence is formed from:
+
+```text
+z_ref_gen = [reference transcript, target text, filler tokens]
+```
+
+and the acoustic condition is:
+
+```text
+[reference mel frames, zeros for the region to generate]
+```
+
+The model's job is to generate the missing target mel frames while preserving
+speaker, timbre, and style information from the reference audio.
+
+## Flow Matching In Plain Terms
+
+Diffusion-style models learn to generate data by moving from noise to a sample.
+Conditional flow matching expresses this as a continuous vector field. Instead
+of predicting the next token, the model predicts "which direction should this
+noisy mel spectrogram move at time `t` so that it becomes real speech by
+`t = 1`?"
+
+F5's implementation uses the optimal-transport conditional path:
+
+```text
+x_t = (1 - t) * x_0 + t * x_1
+u_t = x_1 - x_0
+```
+
+where:
+
+- `x_0` is Gaussian noise with the same shape as the mel spectrogram;
+- `x_1` is the real mel spectrogram;
+- `t ~ Uniform(0, 1)`;
+- `u_t` is the target flow vector;
+- the transformer predicts `v_theta(x_t, condition, text, t)`.
+
+The loss is a masked mean-squared error:
+
+```text
+L = MSE(v_theta(x_t, condition, text, t), x_1 - x_0)
+```
+
+but only over the randomly masked span. This matters: the model is not asked to
+reconstruct the whole utterance uniformly. It is trained as a speech-infilling
+model: "given the unmasked acoustic context and the full text, fill the missing
+audio."
+
+The public F5-TTS implementation mirrors this directly in
+`src/f5_tts/model/cfm.py`: it samples `x0 = torch.randn_like(x1)`, samples a
+random time, builds `phi = (1 - t) * x0 + t * x1`, sets the target `flow = x1 -
+x0`, zeros the random span in the condition, and computes MSE only on the
+masked span.
+
+## Training Algorithm
+
+F5 and E2 share the same high-level training loop.
+
+```text
+input:
+  dataset D of (waveform, transcript) pairs
+  mel extractor M
+  tokenizer T
+  transformer vector-field model v_theta
+  mask fraction range [0.7, 1.0]
+  audio-condition dropout p_audio
+  full-condition dropout p_uncond
+
+for each minibatch:
+  x1 = M(waveform)                         # real mel, shape [B, N, F]
+  z = pad(T(transcript), length=N, token=<F>)
+
+  valid_mask = frames_before_padding(x1)
+  span_mask = random_contiguous_span(valid_mask, fraction in [0.7, 1.0])
+
+  x0 = normal_like(x1)
+  t = uniform(0, 1)
+  xt = (1 - t) * x0 + t * x1
+  target_flow = x1 - x0
+
+  cond_audio = x1 with span_mask set to zero
+
+  if Bernoulli(p_audio):
+    cond_audio = zeros_like(cond_audio)
+
+  if Bernoulli(p_uncond):
+    cond_audio = zeros_like(cond_audio)
+    z = filler-or-zero text condition
+
+  pred_flow = v_theta(xt, cond_audio, z, t)
+  loss = mean_square(pred_flow - target_flow over span_mask)
+  update theta
+
+termination:
+  stop after scheduled updates or epochs; inference uses EMA weights in F5.
+```
+
+The production-relevant invariants are:
+
+- the predicted tensor shape must match the mel tensor shape;
+- the text sequence is truncated or padded to the target acoustic length;
+- the training mask must exclude padding frames;
+- the loss is only valid on the masked span;
+- classifier-free guidance only works because the model sees dropped-condition
+  examples during training.
+
+## Inference Algorithm
+
+At inference time the system takes a short reference audio clip, its transcript,
+and target text. The public API can transcribe the reference audio with Whisper
+if no reference text is provided, but the model itself still conditions on text.
+
+```text
+input:
+  reference waveform x_ref
+  reference transcript y_ref
+  target text y_gen
+  duration N_total
+  number of function evaluations K
+  CFG strength alpha
+  Sway coefficient s
+
+prepare:
+  ref_mel = M(x_ref)
+  z = pad(T(y_ref + y_gen), length=N_total, token=<F>)
+  cond = [ref_mel, zeros for generated duration]
+  cond_mask = true on reference frames, false on generation frames
+  y0 = Gaussian noise [N_total, F]
+
+sample timesteps:
+  u_i = i / K for i = 0..K
+  t_i = u_i + s * (cos(pi * u_i / 2) - 1 + u_i)
+
+integrate ODE:
+  for t_i from 0 to 1:
+    pred_cond = v_theta(y, cond, z, t_i)
+    pred_uncond = v_theta(y, zeros, dropped_text, t_i)
+    dy_dt = pred_cond + alpha * (pred_cond - pred_uncond)
+    y = ODE_step(y, dy_dt)
+
+restore:
+  y[reference frames] = ref_mel
+  generated_mel = y[target frames]
+  waveform = vocoder(generated_mel)
+```
+
+The F5 code defaults to 32 NFE, CFG strength `2.0`, Sway Sampling coefficient
+`-1`, Euler integration for the current F5 API, and Vocos mel decoding unless a
+BigVGAN path is chosen. Duration is not predicted by a learned duration model in
+the default inference script. It is estimated from the ratio between reference
+audio length, reference text length, target text length, and requested speed,
+unless `fix_duration` is supplied.
+
+## Architecture: Transformer, But Not An LLM
+
+The phrase "LLM architecture" is misleading here. F5-TTS uses transformer
+building blocks, but it is not a language model in the autoregressive
+next-token sense:
+
+| Property | Autoregressive LLM | F5-TTS |
+| --- | --- | --- |
+| Output | Discrete text tokens. | Continuous mel-spectrogram flow vectors. |
+| Generation order | Left-to-right token sampling. | Non-autoregressive ODE integration over all frames. |
+| Training target | Next-token cross entropy. | Masked flow-vector MSE. |
+| Time axis | Token positions. | Mel frame positions plus flow time `t`. |
+| Conditioning | Prompt tokens / context window. | Noisy mel, masked reference mel, padded text, flow step. |
+
+F5's base model configuration is DiT-like:
+
+| Component | F5-TTS base setting |
+| --- | --- |
+| Backbone | Diffusion Transformer (`DiT`) |
+| Transformer depth | 22 layers |
+| Hidden dimension | 1024 |
+| Attention heads | 16 |
+| FFN multiplier | 2 |
+| Text dimension | 512 |
+| Text preprocessing | 4 ConvNeXt V2 blocks |
+| Mel representation | 100-bin log mel, 24 kHz audio, hop length 256 |
+| Vocoder | Vocos by default; BigVGAN supported |
+| Public v1 checkpoint | `F5TTS_v1_Base`, safetensors via Hugging Face |
+
+The backbone pipeline is:
+
+```text
+text tokens -> embedding -> sinusoidal position -> ConvNeXt V2 text blocks
+noisy mel + masked mel + refined text -> linear projection
+projected sequence + convolutional position embedding
+DiT blocks with RoPE attention and time-conditioned AdaLN
+final AdaLN + linear projection -> predicted mel flow
+```
+
+The architectural difference from E2 is not that F5 adds a giant text encoder.
+It does the opposite: it keeps the system small enough to remain "text in,
+speech out", but inserts just enough local temporal modeling for text before
+joint speech-text attention. E2's reproduction in the repo uses `UNetT`, a flat
+U-Net-style transformer with skip connections. F5 removes that long U-Net
+structure and uses DiT blocks with adaptive layer normalization conditioned by
+the flow step.
+
+## What Sway Sampling Changes
+
+Uniform ODE timesteps spend equal resolution across the whole noise-to-data
+path. F5 argues that early flow steps are especially important for deciding the
+coarse speech plan: content, alignment, and speaker-conditioned trajectory.
+Sway Sampling reshapes uniformly spaced values `u` into timesteps:
+
+```text
+t = u + s * (cos(pi * u / 2) - 1 + u)
+```
+
+with `s < 0` shifting more function evaluations toward smaller `t`. This is an
+inference-time change. It does not require retraining because it only changes
+where the ODE solver evaluates the learned vector field.
+
+In the F5 paper's ablation, Sway Sampling improves both F5 and E2. On
+LibriSpeech-PC test-clean, F5-TTS with 32 NFE improves from 2.84 WER without
+Sway Sampling to 2.41 WER with it in the Table 5 midpoint-solver ablation. The
+same table reports E2 improving from 2.95 WER to 2.84 WER at 32 NFE with Sway
+Sampling. The improvement is larger for F5 because its architecture is already
+more robust to text-audio alignment.
+
+## Performance Claims And How To Read Them
+
+E2 TTS reports unusually strong zero-shot English results on LibriSpeech-PC
+test-clean:
+
+| System | Data | WER (%) lower is better | SIM-o higher is better |
+| --- | ---: | ---: | ---: |
+| Ground truth | - | 2.0 | 0.695 |
+| VALL-E | 60K h English | 4.9 | 0.500 |
+| NaturalSpeech 3 | 60K h English | 2.6 | 0.632 |
+| Voicebox reproduction | 50K h English | 2.2 | 0.667 |
+| E2 TTS | 50K h English | 2.0 | 0.675 |
+| E2 TTS + unsupervised pretraining | 50K h English | 1.9 | 0.708 |
+| E2 TTS | 200K h proprietary | 1.9 | 0.707 |
+
+The most important caveat is that E2's headline results are English and partly
+depend on very large training data or pretraining. The F5 paper's reproduction
+finds E2 strong in speaker similarity but less robust in multilingual
+zero-shot settings, especially Mandarin, where the paper reports persistent
+failure cases with WER over 50% for a subset of samples during training.
+
+F5's main table reports these LibriSpeech-PC results on a released 1,127-sample
+4-to-10-second subset:
+
+| System | Training data | WER (%) | SIM-o | RTF |
+| --- | ---: | ---: | ---: | ---: |
+| Ground truth | - | 2.23 | 0.69 | - |
+| Vocoder resynthesis | - | 2.32 | 0.66 | - |
+| CosyVoice | 170K h multilingual | 3.59 | 0.66 | 0.92 |
+| FireRedTTS | 248K h multilingual | 2.69 | 0.47 | 0.84 |
+| E2 TTS reproduction, 32 NFE | 100K h multilingual | 2.95 | 0.69 | 0.68 |
+| F5-TTS, 16 NFE | 100K h multilingual | 2.53 | 0.66 | 0.15 |
+| F5-TTS, 32 NFE | 100K h multilingual | 2.42 | 0.66 | 0.31 |
+
+This table should not be read as "F5 dominates every model on every metric."
+The published baseline rows combine different model sizes, datasets, languages,
+and disclosed evaluation conditions. The reliable conclusion is narrower and
+more useful: F5 preserves the simple E2 pipeline while improving robustness and
+real-time factor against the authors' E2 reproduction under their released
+evaluation setup.
+
+The repo README reports an even lower deployment RTF when the model is served
+through Triton/TensorRT-LLM on an L20 GPU: about 0.039-0.040 RTF for server or
+offline TRT-LLM modes versus about 0.147 RTF for offline PyTorch under the
+README's 16-NFE benchmark. That is an implementation/deployment result, not the
+same condition as the paper's RTX 3090 table, but it is useful for operational
+expectations.
+
+## Practical Engineering Implications
+
+F5-TTS is attractive because its training recipe is simple for a modern neural
+TTS system:
+
+- no phoneme aligner is required;
+- no learned duration model is required for the default path;
+- no autoregressive codec-token language model is required;
+- the same model supports zero-shot voice cloning, speech editing-style
+  infilling, code switching, and speed control through duration.
+
+But the simplicity pushes responsibility into the data and the conditioning:
+
+| Issue | Mechanism | Practical consequence |
+| --- | --- | --- |
+| Reference transcript quality matters. | The prompt transcript is concatenated with generated text. | ASR errors in reference text can leak into alignment or pronunciation. |
+| Duration is still a control variable. | Filler tokens need a target frame count. | Bad duration estimates can cause rushed speech, silence, truncation, or stretched prosody. |
+| Text-audio length mismatch is learned, not solved. | Characters are padded to mel length without explicit boundaries. | Out-of-distribution text, repetitions, and rare pronunciations can still break alignment. |
+| CFG doubles inference work when used literally. | Conditional and unconditional vector fields are both evaluated. | Latency depends strongly on CFG, NFE, solver, and batching. |
+| Vocoder affects measured WER and quality. | The flow model outputs mel features, not waveform. | Vocos and BigVGAN can shift intelligibility, similarity, and latency. |
+
+For fine-tuning, the practical recipe is to preserve the model's infilling
+assumption. A dataset should provide clean audio paths and transcripts; the repo
+expects CSV-style `audio_file|text` metadata for custom data preparation. The
+base model uses frame-based batching, 24 kHz audio, 100 mel channels, and a
+learning-rate schedule around `7.5e-5` for full training. Fine-tuning with only a
+few updates may need EMA disabled because early EMA weights can remain dominated
+by the pretrained checkpoint.
+
+## The Core Insight
+
+The real lesson of E2/F5 is that text-speech alignment can be shifted from a
+separate symbolic preprocessing problem into the continuous generative model,
+provided the model is trained as masked speech infilling over large paired
+speech-text data. E2 proves the idea. F5 makes it more practical by reducing
+the worst optimization pathology: raw padded characters and dense acoustic
+frames are too mismatched to simply concatenate and hope for robust alignment.
+ConvNeXt text refinement gives the character stream a local temporal model
+before joint attention, while DiT/AdaLN conditioning gives the flow step a
+cleaner role than appending time as another token.
+
+This is why F5-TTS is a useful design pattern beyond this specific repository:
+if a task requires aligning a sparse symbolic condition to a dense continuous
+sequence, a small modality-specific preprocessing stage before a shared
+diffusion/flow transformer can outperform both extremes: fully hand-engineered
+alignment and fully raw concatenation.
+
+## Sources
+
+- Sefik Emre Eskimez et al., "E2 TTS: Embarrassingly Easy Fully
+  Non-Autoregressive Zero-Shot TTS", arXiv:2406.18009,
+  https://arxiv.org/abs/2406.18009.
+- Yushen Chen et al., "F5-TTS: A Fairytaler that Fakes Fluent and Faithful
+  Speech with Flow Matching", ACL 2025 / arXiv:2410.06885,
+  https://aclanthology.org/2025.acl-long.313/ and
+  https://arxiv.org/abs/2410.06885.
+- SWivid/F5-TTS official repository, inspected at commit `2ae2c9b`,
+  https://github.com/SWivid/F5-TTS.
+- F5-TTS implementation files: `src/f5_tts/model/cfm.py`,
+  `src/f5_tts/model/backbones/dit.py`, `src/f5_tts/model/backbones/unett.py`,
+  `src/f5_tts/infer/utils_infer.py`, and `src/f5_tts/configs/F5TTS_v1_Base.yaml`
+  in the official repository.


### PR DESCRIPTION
Adds two durable speech-synthesis insights: one on F5-TTS/E2-TTS flow-matching architecture and one on Resemble AI Chatterbox internals.

Includes the corresponding deep-research source audits under `brain/inbox/dr/` so the claims, caveats, and benchmarks have an evidence trail.

The notes explain model data flow, training signals visible from public code and papers, performance claims, and production failure modes for engineers evaluating these TTS systems.

Validation: reviewed the staged and PR diffs, and ran `git diff --cached --check`.
