### PR TITLE
[codex] Add BPM research insight

### DIFF
--- a/brain/inbox/dr/bpm-business-process-management/source-synthesis.md
+++ b/brain/inbox/dr/bpm-business-process-management/source-synthesis.md
@@ -1,0 +1,153 @@
+# BPM Research Source Synthesis
+
+Date: 2026-07-02
+
+Topic: Business Process Management (BPM): what it is, how it is used, and
+whether it remains popular.
+
+## Research Log
+
+I attempted a `dr research` run for the definition and lifecycle lane:
+
+```text
+dr research "Business process management BPM definition lifecycle and conceptual model: what BPM is, how it differs from workflow automation, business process reengineering, process mining, and BPMN; prioritize standards, academic sources, and durable sources" --env-file go-research/.env --effort standard --max-searches 5 --max-sources 10 --output brain/inbox/dr/bpm-business-process-management/01-definition-lifecycle.md
+```
+
+The run reached citation verification and multiple refinement passes but stalled
+before writing the output file. I terminated the single stuck `dr research`
+process and archived this manual source synthesis instead. The source set below
+uses the same research lanes: definitions, lifecycle, standards/tooling,
+process mining, adoption signals, and caveats.
+
+## Source Register
+
+| ID | Source | Type | Admitted Use |
+| --- | --- | --- | --- |
+| S1 | [Wikipedia: Business process management](https://en.wikipedia.org/wiki/Business_process_management) | Tertiary orientation | Useful for initial taxonomy and common definitions only; the article itself warns that it needs more citations. |
+| S2 | [Workflow Management Coalition: What is BPM?](https://wfmc.org/what-is-bpm/) | Professional definition | Concise definition of BPM as modeling, automation, execution, control, measurement, and optimization across people, systems, partners, and customers. |
+| S3 | [ISO: The process approach in ISO 9001:2015](https://www.iso.org/iso/iso9001_2015_process_approach.pdf) | Standards guidance | Defines a process as interrelated activities with inputs and outputs; frames process management as an integrated system using PDCA and risk-based thinking. |
+| S4 | [Springer: Fundamentals of Business Process Management](https://www.springerprofessional.de/en/fundamentals-of-business-process-management/15562224) | Academic textbook page | Supports the lifecycle framing: identification, modeling, analysis, redesign, automation, and monitoring. |
+| S5 | [OMG: BPMN overview](https://www.omg.org/bpmn/) | Standards body | Establishes BPMN / ISO/IEC 19510 as a standard notation and semantic model for process, collaboration, and choreography diagrams. |
+| S6 | [OMG: BPMN 2.0.2 specification page](https://www.omg.org/spec/BPMN/2.0.2/About-BPMN) | Standards body | Describes BPMN 2.0.2 as a formal specification intended for both process stakeholders and software implementation. |
+| S7 | [OMG / ISO: BPMN ISO/IEC 19510 PDF](https://www.omg.org/spec/BPMN/ISO/19510/PDF) | Formal standard | Provides the standard's scope, bridge between business users and implementers, conformance types, and BPMN limits. |
+| S8 | [Gartner Peer Insights: BPM platforms](https://www.gartner.com/reviews/market/business-process-management-platforms) | Analyst category page | Defines minimum BPM platform capabilities: modeling, metadata repository, execution engine, and state/rule engine. |
+| S9 | [Gartner Peer Insights: Business process automation tools](https://www.gartner.com/reviews/market/business-process-automation-tools) | Analyst category page | Shows the current software-market vocabulary shifting toward BPA: design, execution, monitoring, modeling, integrations, task management, and case management. |
+| S10 | [Gartner: Market Guide for Business Process Automation Tools](https://www.gartner.com/en/documents/6495671) | Analyst report abstract | Current market signal: Gartner published a BPA Market Guide on 2025-05-20 for digital transformation and cost optimization use cases. |
+| S11 | [IEEE Task Force on Process Mining: Process Mining Manifesto](https://www.tf-pm.org/upload/1580737614108.pdf) | Research manifesto | Establishes process mining as event-log-based discovery, conformance checking, and enhancement of operational processes. |
+| S12 | [Gartner Peer Insights: Process Intelligence Platforms](https://www.gartner.com/reviews/market/process-intelligence-platforms) | Analyst category page | Shows adjacent process-intelligence vocabulary: mining, analysis, modeling, design, monitoring, anomaly detection, and decision support. |
+| S13 | [Camunda: 2024 State of Process Orchestration report summary](https://camunda.com/blog/2024/01/state-of-process-orchestration-report-2024/) | Vendor survey | Adoption signal only: survey reports high automation investment intent and roughly half of business processes automated among respondents. |
+| S14 | [Camunda: 2026 State of Agentic Orchestration and Automation](https://camunda.com/state-of-agentic-orchestration-and-automation/) | Vendor survey | Adoption signal only: survey reports planned automation-spend increases and growing endpoint counts. |
+| S15 | [Fortune Business Insights: BPM market size](https://www.fortunebusinessinsights.com/business-process-management-bpm-market-102639) | Market research vendor | Weak but current market-size signal; useful only with caveat that market-sizing pages are not primary adoption measurements. |
+| S16 | [BPM Conference official site](https://bpm-conference.org/) and [Springer BPM conference page](https://link.springer.com/conference/bpm) | Academic community | Shows BPM as an ongoing research field with a conference series since 2003 and a 24th edition planned for 2026. |
+| S17 | [Times of India: BPM sector navigates slowdown, automation](https://timesofindia.indiatimes.com/city/bengaluru/bpm-sector-navigates-slowdown-automation/articleshow/121448158.cms) | Business news | Service-sector signal only; note that "BPM sector" often means business process services / outsourcing, not just BPM software or discipline. |
+| S18 | [Economic Times: BPM deal value and AI](https://economictimes.indiatimes.com/tech/technology/a-62-rise-in-bpm-deal-value-belies-fears-of-ai-dominance/articleshow/131358051.cms?from=mdr) | Business news | Recent service-market signal that AI has not erased demand for process-domain expertise; use with services-sector caveat. |
+
+## Evidence Notes
+
+### Definition
+
+The stronger sources converge on one idea: BPM is a management discipline for
+end-to-end business processes, not merely a diagramming notation or workflow
+engine. WfMC emphasizes modeling, automation, execution, control, measurement,
+and optimization across organizational boundaries. ISO's process-approach
+guidance provides the underlying management-system concept: organizations meet
+objectives through interrelated activities that use inputs to produce intended
+results, and those processes should be integrated, measured, controlled, and
+improved.
+
+Wikipedia is directionally aligned with WfMC, ABPMP, and Gartner definitions,
+but the article carries a citation-warning banner. It should be treated as a
+starting point, not authority.
+
+### Lifecycle And Mechanism
+
+The stable BPM lifecycle is a control loop rather than a one-time project:
+identify the process portfolio, discover or model the current process, analyze
+performance and risk, redesign the target process, execute or automate the
+process, monitor outcomes, and feed observations back into the next redesign.
+Springer's textbook page explicitly covers identification through monitoring,
+including modeling, analysis, redesign, and automation. ISO's PDCA framing gives
+the same loop at management-system level.
+
+### Standards And Tooling
+
+BPMN is the dominant process-modeling notation. OMG and ISO/IEC 19510 position
+it as a standard notation that bridges business analysts, implementers, and
+process managers. The standard also matters because it defines machine-readable
+model interchange and conformance points, but it is not a complete programming
+or monitoring system. The BPMN standard explicitly narrows its scope to business
+process modeling and leaves operational simulation, monitoring, and deployment
+outside the standard itself.
+
+Gartner's BPM platform category requires more than drawings: model/rule
+modeling, a repository, an execution engine, and state or rules. Gartner's BPA
+tool category uses newer wording around design, execution, monitoring,
+integrations, task management, and case management. This supports the conclusion
+that the market vocabulary has shifted from "BPM suite" toward automation,
+orchestration, process intelligence, and low-code automation, while the core
+process-management problem remains.
+
+### Process Mining And Process Intelligence
+
+The Process Mining Manifesto makes the evidence turn in modern BPM explicit:
+event logs allow analysts to discover actual process behavior, compare reality
+against intended models, and enhance process models. Gartner's process
+intelligence category uses similar ingredients: mining, analysis, modeling,
+design, monitoring, anomaly detection, threshold tracking, and decision support.
+This is the main reason contemporary BPM is less workshop-only than older
+process-improvement programs: if systems record case IDs, activities,
+timestamps, actors, and outcomes, the process can be measured directly.
+
+### Popularity And Adoption
+
+The answer is "popular, but under several names."
+
+Strong evidence of durability:
+
+- BPM has an active academic conference series from 2003 through at least the
+  planned 24th edition in 2026.
+- Gartner still maintains BPM platform, BPA tool, and process intelligence
+  categories.
+- The process mining ecosystem has become an adjacent commercial and research
+  field.
+
+Weaker but current commercial signals:
+
+- Fortune Business Insights estimates the BPM market at USD 21.51B in 2025,
+  growing to USD 91.87B by 2034. This is useful as a market-research signal, not
+  as audited adoption.
+- Camunda's vendor surveys report high automation-spend intent among automation
+  leaders, but this respondent pool is not representative of all organizations.
+- Indian and global "BPM sector" articles show large business process services
+  demand, but that sector often means outsourced business process services rather
+  than the BPM discipline or BPM software category alone.
+
+The defensible synthesis is that BPM remains important in enterprise operations,
+compliance, shared services, and automation programs. The exact "BPM" label is
+less fashionable in developer-facing marketing than "process automation,"
+"workflow orchestration," "process intelligence," "low-code automation," "RPA,"
+or "agentic orchestration."
+
+## Claim Verification
+
+| Claim | Verdict | Rationale |
+| --- | --- | --- |
+| BPM is a management discipline, not only software. | Supported | WfMC, ISO, Springer, Gartner BPM platform distinctions. |
+| BPM commonly follows a lifecycle of identify/model/analyze/redesign/execute/monitor/improve. | Supported | Springer textbook page and ISO PDCA/process approach; Wikipedia aligns but is not sole support. |
+| BPMN is a standard notation, not the whole of BPM. | Supported | OMG and ISO/IEC 19510 define BPMN's modeling scope and conformance types. |
+| Process mining is a modern evidence layer for BPM. | Supported | IEEE Process Mining Manifesto and Gartner process intelligence category. |
+| BPM is popular. | Medium support | Strong support for ongoing enterprise/academic/tool-market relevance; exact popularity depends on whether "BPM" means discipline, software, or outsourced services. |
+| AI will eliminate BPM. | Not supported | Current service-market and vendor-survey sources show transformation, not elimination. Evidence is early and mixed. |
+
+## Final Evaluation
+
+Coverage: 4/5. The synthesis covers definition, lifecycle, standards, software
+categories, process mining, adoption, and caveats.
+
+Source quality: 3.5/5. Standards and academic sources are strong. Popularity
+evidence relies partly on analyst abstracts, vendor surveys, and market-research
+pages, so those claims should be phrased cautiously.
+
+Main gap: audited, independent enterprise adoption statistics are hard to obtain
+without paid analyst reports or proprietary survey microdata. Treat market-size
+and vendor-survey numbers as directional signals.

--- a/brain/insights/bpm-business-process-management.md
+++ b/brain/insights/bpm-business-process-management.md
@@ -1,0 +1,322 @@
+---
+type: insight
+title: "Business Process Management Is Process Governance, Not Workflow Glue"
+slug: bpm-business-process-management
+created: 2026-07-02
+status: working
+publish: false
+tags:
+  - operations
+---
+
+# Business Process Management Is Process Governance, Not Workflow Glue
+
+BPM, or Business Process Management, is the discipline of treating recurring
+cross-functional work as a managed system: identify the process, model how it
+should work, measure how it actually works, redesign it, execute or automate it,
+and keep improving it as conditions change. The important distinction is that
+BPM is not the same thing as BPMN diagrams, workflow software, RPA scripts, or a
+one-time process-improvement project. Those are instruments. BPM is the control
+loop that decides which processes matter, how they should behave, who owns them,
+which measurements prove they are healthy, and how changes are governed.
+
+## What BPM Means
+
+ISO's [process-approach guidance](https://www.iso.org/iso/iso9001_2015_process_approach.pdf)
+defines the base unit: a process is a set of interrelated or interacting
+activities that use inputs to deliver an intended result. That definition
+matters because BPM is not organized around departments, org-chart boxes, or
+individual tasks. It is organized around value-producing flows such as
+quote-to-cash, procure-to-pay, employee onboarding, customer support escalation,
+loan origination, claims handling, order fulfillment, or regulatory approval.
+
+Professional BPM definitions differ in wording, but they converge on the same
+shape:
+
+| Lens | BPM Emphasis | Practical Meaning |
+| --- | --- | --- |
+| Management discipline | Processes are assets to be designed, measured, controlled, and improved. | A process has an owner, target outcomes, metrics, controls, and a change cadence. |
+| Cross-functional work | Processes span people, systems, partners, and customers. | The hard problem is usually handoff quality, not one team's local efficiency. |
+| Lifecycle | Modeling, execution, monitoring, and optimization form a loop. | A process model is stale unless runtime data and exceptions feed back into it. |
+| Technology-enabled, not technology-defined | BPMS, workflow engines, RPA, process mining, and low-code tools support BPM. | Buying a platform does not create BPM capability unless governance and measurement exist. |
+
+This is why BPM is often confused with adjacent terms:
+
+| Term | Relationship To BPM |
+| --- | --- |
+| Workflow automation | Automates routing and task execution for part or all of a process. BPM decides whether that workflow is the right process and how it is governed. |
+| BPMN | A standard notation for process models. BPMN can document and sometimes execute process logic, but it is not the management discipline. |
+| BPMS / BPM platform | A software suite for modeling, executing, monitoring, and managing processes. It is a tool implementation of BPM ideas. |
+| RPA | Automates repetitive UI-level tasks. It can be a tactical implementation inside a BPM program, but it can also preserve a broken process by automating its symptoms. |
+| Process mining | Uses event logs to discover, check, and improve real process behavior. It supplies evidence to the BPM monitoring and redesign loop. |
+| Project management | Manages unique work. BPM manages recurring or at least repeatable patterns of work, including variable cases with known rules and exceptions. |
+
+## The Mechanism: A Control Loop Over Work
+
+The useful mental model is a feedback system:
+
+```mermaid
+flowchart LR
+  Strategy[Strategy and constraints]
+  Portfolio[Process architecture]
+  Model[As-is and to-be model]
+  Execute[Execution and automation]
+  Log[Event logs and case data]
+  Analyze[Monitoring, mining, analysis]
+  Redesign[Redesign and controls]
+
+  Strategy --> Portfolio
+  Portfolio --> Model
+  Model --> Execute
+  Execute --> Log
+  Log --> Analyze
+  Analyze --> Redesign
+  Redesign --> Model
+  Analyze --> Strategy
+```
+
+In a mature implementation, each loop has explicit state:
+
+| State | Artifact | Typical Owner | Quality Question |
+| --- | --- | --- | --- |
+| Process portfolio | Process architecture, value-chain map, ownership matrix | COO, transformation office, enterprise architect | Which processes matter enough to govern? |
+| Current behavior | Interviews, observations, event logs, current-state BPMN | Process analyst, domain lead | What actually happens, including exceptions? |
+| Target behavior | To-be model, policies, decision rules, controls | Process owner, compliance, product/operations lead | What should happen, and under which conditions? |
+| Runtime execution | Workflow engine, case manager, API orchestration, task queues | Engineering, operations, platform team | Can the process execute consistently across people and systems? |
+| Measurement | KPIs, SLAs, event logs, bottleneck reports, conformance checks | Process owner, analytics, audit | Are outcomes improving, and where is reality drifting from design? |
+| Governance | Change backlog, release process, risk controls, audit trail | Process owner, governance board | Who can change the process, and what evidence justifies the change? |
+
+The loop can be written as organizational pseudocode:
+
+```text
+procedure BPM_CONTROL_LOOP(strategy, processPortfolio, eventSources):
+  for each reviewCycle:
+    candidateProcesses = rank_by(strategy, risk, cost, customer_impact)
+
+    for each process in candidateProcesses:
+      owner = require_process_owner(process)
+      currentModel = discover_current_state(process, interviews, eventSources)
+      baseline = measure(currentModel, eventSources, target_metrics)
+
+      gaps = compare(
+        observed_behavior = baseline.event_log_patterns,
+        expected_behavior = currentModel.rules_and_paths,
+        objectives = strategy.process_objectives
+      )
+
+      if gaps are material:
+        targetModel = redesign(process, gaps, constraints, controls)
+        executionPlan = choose_implementation(targetModel)
+        deploy(executionPlan)
+        instrument(process, case_id, activity, timestamp, actor, outcome)
+
+      report(owner, metrics, exceptions, residual_risk)
+```
+
+The invariant is that process changes remain tied to measurable business
+outcomes and accountable ownership. The loop does not naturally terminate; it
+slows down when the process is stable, low-risk, and meeting objectives. The
+main complexity drivers are cross-system integration, exception volume,
+regulatory constraints, unclear ownership, and poor event data. Precision is
+lost whenever the model hides informal work, merges multiple real cases into
+one "happy path," or records events without a reliable case identifier.
+
+## How BPM Is Used
+
+In practice, BPM programs usually start where work crosses boundaries and local
+optimization is not enough:
+
+| Use Case | BPM Role | Typical Technology |
+| --- | --- | --- |
+| Order-to-cash | Align sales, finance, fulfillment, billing, collections, and customer communication. | BPMN model, workflow engine, ERP/CRM integration, SLA dashboards. |
+| Procure-to-pay | Standardize requisitions, approvals, vendor onboarding, purchase orders, receiving, and payment. | Forms, rules, task routing, document management, ERP connectors. |
+| Insurance or healthcare claims | Coordinate documents, eligibility checks, decisions, exceptions, and audit trails. | Case management, decision rules, content management, analytics. |
+| Loan origination | Combine customer input, risk checks, underwriting, compliance, approvals, and status updates. | Workflow/case engine, rules engine, identity/data integrations. |
+| Employee onboarding | Coordinate HR, IT access, legal, payroll, manager tasks, equipment, and training. | Task management, identity provisioning, notifications, event logs. |
+| Regulatory processes | Prove that required controls executed and exceptions were handled. | Process repository, audit trail, conformance checks, reporting. |
+| Customer support escalation | Route cases by severity, entitlement, skill, SLA risk, and customer context. | Case management, queues, rules, knowledge systems, monitoring. |
+
+The software stack varies, but a complete BPM implementation usually needs five
+capabilities:
+
+1. Model the process in a notation that business and technical stakeholders can
+   review.
+2. Execute the process through workflow, case management, API orchestration, or
+   human task routing.
+3. Integrate with systems of record instead of retyping data across screens.
+4. Observe runtime behavior through event logs, metrics, and exception capture.
+5. Govern change through ownership, versioning, controls, and auditability.
+
+This is why Gartner's
+[BPM platform category](https://www.gartner.com/reviews/market/business-process-management-platforms)
+requires more than a drawing canvas: it includes modeling, a metadata
+repository, an execution engine, and state or rule management. Gartner's newer
+[business process automation category](https://www.gartner.com/reviews/market/business-process-automation-tools)
+uses more current language but points at the same operational substrate:
+designing, executing, monitoring, integrating, task-managing, and case-managing
+business processes.
+
+## BPMN Matters, But It Has Boundaries
+
+BPMN is the dominant process notation because it is designed to be readable by
+business stakeholders while still precise enough for technical implementation.
+The [OMG / ISO standard](https://www.omg.org/spec/BPMN/ISO/19510/PDF) frames
+BPMN as a bridge between process design and implementation, with constructs for
+events, activities, gateways, pools, lanes, messages, data associations, and
+exceptions.
+
+That bridge is useful, but it creates a trap: teams may treat a BPMN diagram as
+the process. It is only a representation. A process model becomes operationally
+valuable when it is connected to:
+
+- ownership and decision rights;
+- runtime state and case identifiers;
+- service-level targets and business outcomes;
+- exception handling and escalation policy;
+- event logs that let analysts compare intended behavior with actual behavior;
+- a change process for versioning and communicating redesigns.
+
+The BPMN standard itself does not solve simulation, deployment, monitoring, or
+organizational adoption. It provides notation and semantics. BPM supplies the
+management system around that notation.
+
+## Process Mining Turned BPM Into An Evidence Problem
+
+Older BPM work could become workshop-driven: interview people, draw the process,
+argue about the right future state, and hope the redesign lands. Process mining
+changes the evidence model. Given event logs with a case ID, activity name,
+timestamp, actor, and relevant attributes, process-mining tools can infer actual
+paths, check conformance against a model, find bottlenecks, and surface variants
+that the official process never acknowledged.
+
+That does not make mining magic. It depends on log quality:
+
+| Requirement | Why It Matters |
+| --- | --- |
+| Stable case ID | Without it, events cannot be grouped into process instances. |
+| Meaningful activity names | Low-level system events may not map cleanly to business activities. |
+| Ordered timestamps | Duration, waiting time, and bottleneck analysis need reliable time data. |
+| Actor or role | Handoff and responsibility analysis need organizational context. |
+| Outcome and exception markers | Optimization needs to distinguish successful, failed, cancelled, and exceptional cases. |
+| Model provenance | Analysts need to know whether a model was designed, mined, manually edited, or generated. |
+
+The [Process Mining Manifesto](https://www.tf-pm.org/upload/1580737614108.pdf)
+captures the key evidence turn: modern systems already record traces of
+operational work, and those traces can be used to discover, monitor, and improve
+real processes rather than assumed processes. Current
+[process intelligence](https://www.gartner.com/reviews/market/process-intelligence-platforms)
+platforms extend this idea with anomaly detection, threshold tracking, decision
+support, and links back into process design.
+
+## Is BPM Popular?
+
+Yes, but the answer depends on what "BPM" means.
+
+If BPM means the management discipline, it is durable. It has a long-running
+academic community, an active
+[International Conference on Business Process Management](https://bpm-conference.org/)
+series since 2003, standards such as BPMN / ISO/IEC 19510, and a large
+professional ecosystem around process improvement, automation, compliance,
+process mining, and operational excellence.
+
+If BPM means the software label, the term is less fashionable than it used to
+be. The market has fragmented into names such as business process automation,
+digital process automation, workflow automation, process orchestration, process
+intelligence, process mining, low-code automation, case management, RPA, and now
+agentic orchestration. Gartner still maintains a BPM platform category, but its
+[2025 Market Guide](https://www.gartner.com/en/documents/6495671) language
+around business process automation reflects the shift toward automation and
+monitoring as the buying vocabulary.
+
+If BPM means the outsourced services sector, it is large but semantically
+messy. Business news often uses "BPM" for business process management/services
+firms that run operations for clients, overlapping with older BPO/BPS language.
+Those sources show continued demand for process-domain expertise, especially as
+AI changes delivery models, but they should not be confused with adoption of BPM
+software or the BPM discipline inside one enterprise.
+
+Current popularity signals are directional, not exact:
+
+| Signal | What It Suggests | Caveat |
+| --- | --- | --- |
+| Gartner BPM platform, BPA, and process intelligence categories | Enterprises still buy tools for modeling, executing, monitoring, and analyzing processes. | Analyst category pages are market taxonomies, not adoption surveys. |
+| Camunda 2024 and 2026 automation surveys | Automation leaders report high investment intent and many process endpoints. | Vendor survey; respondent pool is already automation-oriented. |
+| Fortune Business Insights market estimate | Commercial analysts expect BPM market growth through the 2030s. | Market-size pages are directional and often opaque about methodology. |
+| BPM conference series and Springer proceedings | BPM remains an active research field. | Academic activity is not the same as mainstream enterprise adoption. |
+| Business process services news | Process-domain labor and services remain economically meaningful. | Services-sector "BPM" often means outsourced operations, not BPM tooling. |
+
+The best synthesis: BPM is popular in enterprise operations but less visible
+under its old name. The underlying need has grown because organizations have
+more SaaS systems, more integration points, more compliance requirements, more
+automation tools, and now more AI agents acting inside business workflows.
+
+## Why AI Makes BPM More Important, Not Less
+
+AI can automate tasks inside a process, but it does not remove the need for
+process control. In fact, AI increases the need for explicit BPM mechanics:
+
+- What process instance is this AI action attached to?
+- Which policy, rule, or approval gave the AI permission to act?
+- What evidence was used?
+- What should happen when the model is uncertain?
+- Which exceptions require human review?
+- How is the outcome measured?
+- How can the organization prove after the fact that the process followed its
+  controls?
+
+Without that machinery, agentic automation becomes a collection of impressive
+task completions with weak operational accountability. BPM gives AI systems a
+case model, state transitions, audit trail, escalation policy, and performance
+loop.
+
+## Failure Modes
+
+BPM fails when it becomes theater.
+
+| Failure Mode | Mechanism | Better Test |
+| --- | --- | --- |
+| Diagram worship | The organization maintains beautiful process maps that do not match actual work. | Compare the model to event logs and exception reports. |
+| Local optimization | One department improves its queue while increasing total cycle time. | Measure end-to-end customer or case outcomes. |
+| Automation over broken work | RPA or workflow tools encode waste instead of removing it. | Redesign before automating; automate only after root-cause analysis. |
+| Happy-path modeling | Exceptions, rework, cancellations, and manual overrides are omitted. | Require variant and exception coverage before implementation. |
+| No process owner | Everyone participates, but nobody can change policy, resources, or tooling. | Assign accountable ownership and decision rights. |
+| Weak instrumentation | Logs cannot reconstruct cases or handoffs. | Define the event schema before rollout. |
+| Executable-diagram overreach | Teams force business ambiguity into brittle executable BPMN. | Use BPMN where it clarifies control flow; use code, rules, or case logic where those are better abstractions. |
+| AI opacity | AI decisions are embedded in workflows without provenance or escalation rules. | Log prompts, inputs, outputs, confidence, approvals, and override paths where policy requires it. |
+
+## Practical Takeaways
+
+1. Start BPM work by naming the process instance, owner, objective, and outcome
+   metric. A diagram without those is documentation, not management.
+2. Treat BPMN as a shared language, not a universal runtime. Use it where
+   standardized process communication matters.
+3. Instrument before optimizing. If the event log cannot reconstruct the case,
+   process mining and conformance checks will be misleading.
+4. Separate process governance from automation tooling. A workflow engine can
+   execute a bad process perfectly.
+5. Evaluate BPM popularity by the problem, not the acronym. The current market
+   may call it automation, orchestration, or process intelligence, but the
+   durable question is still: how does this organization control and improve
+   cross-functional work?
+
+## Sources
+
+- [Wikipedia: Business process management](https://en.wikipedia.org/wiki/Business_process_management)
+- [Workflow Management Coalition: What is BPM?](https://wfmc.org/what-is-bpm/)
+- [ISO: The process approach in ISO 9001:2015](https://www.iso.org/iso/iso9001_2015_process_approach.pdf)
+- [Springer: Fundamentals of Business Process Management](https://www.springerprofessional.de/en/fundamentals-of-business-process-management/15562224)
+- [OMG: Business Process Model and Notation](https://www.omg.org/bpmn/)
+- [OMG: About BPMN 2.0.2](https://www.omg.org/spec/BPMN/2.0.2/About-BPMN)
+- [OMG / ISO: BPMN ISO/IEC 19510 PDF](https://www.omg.org/spec/BPMN/ISO/19510/PDF)
+- [Gartner Peer Insights: Business Process Management Platforms](https://www.gartner.com/reviews/market/business-process-management-platforms)
+- [Gartner Peer Insights: Business Process Automation Tools](https://www.gartner.com/reviews/market/business-process-automation-tools)
+- [Gartner: Market Guide for Business Process Automation Tools](https://www.gartner.com/en/documents/6495671)
+- [IEEE Task Force on Process Mining: Process Mining Manifesto](https://www.tf-pm.org/upload/1580737614108.pdf)
+- [Gartner Peer Insights: Process Intelligence Platforms](https://www.gartner.com/reviews/market/process-intelligence-platforms)
+- [Camunda: 2024 State of Process Orchestration report summary](https://camunda.com/blog/2024/01/state-of-process-orchestration-report-2024/)
+- [Camunda: 2026 State of Agentic Orchestration and Automation](https://camunda.com/state-of-agentic-orchestration-and-automation/)
+- [Fortune Business Insights: BPM market size](https://www.fortunebusinessinsights.com/business-process-management-bpm-market-102639)
+- [International Conference on Business Process Management](https://bpm-conference.org/)
+- [Springer: BPM conference proceedings](https://link.springer.com/conference/bpm)
+- [Times of India: BPM sector navigates slowdown, automation](https://timesofindia.indiatimes.com/city/bengaluru/bpm-sector-navigates-slowdown-automation/articleshow/121448158.cms)
+- [Economic Times: BPM deal value and AI](https://economictimes.indiatimes.com/tech/technology/a-62-rise-in-bpm-deal-value-belies-fears-of-ai-dominance/articleshow/131358051.cms?from=mdr)


### PR DESCRIPTION
Adds a BPM research source synthesis under `brain/inbox/dr` and a durable insight note under `brain/insights`.

The insight explains BPM as a process governance/control loop, distinguishes BPM from BPMN, workflow automation, RPA, and process mining, and summarizes practical usage, popularity signals, AI implications, and failure modes.

Validation: `pnpm lint`.
