### PR TITLE
Add RSS and Atom feeds for blog subscriptions

### DIFF
--- a/app/blog/[slug]/page.tsx
+++ b/app/blog/[slug]/page.tsx
@@ -1,5 +1,6 @@
 import Link from 'next/link';
 import { getPostBySlug, getAllSlugs } from '@/lib/posts';
+import { feedAlternates } from '@/lib/site';
 import { notFound } from 'next/navigation';
 import type { Metadata } from 'next';
 import type { ReactNode } from 'react';
@@ -32,6 +33,10 @@ export async function generateMetadata({
   return {
     title: `${post.title} | addcommitpush.io`,
     description: post.description,
+    alternates: {
+      canonical: `/blog/${post.slug}`,
+      types: feedAlternates,
+    },
     openGraph: {
       title: post.title,
       description: post.description,

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -4,6 +4,7 @@ import { IBM_Plex_Mono, Spectral } from 'next/font/google';
 import { Suspense } from 'react';
 import './globals.css';
 import { Navigation } from '@/components/navigation';
+import { feedAlternates, siteConfig } from '@/lib/site';
 import { PHProvider } from './providers';
 import { PostHogPageView } from './posthog-pageview';
 
@@ -21,28 +22,29 @@ const spectral = Spectral({
 });
 
 export const metadata: Metadata = {
+  metadataBase: new URL(siteConfig.url),
   title: {
-    default: 'addcommitpush.io - Emil Wåreus',
+    default: siteConfig.title,
     template: '%s | addcommitpush.io',
   },
-  description:
-    'Tech blog by Emil Wåreus. Head of Engineering and Research. Writing about machine learning, data engineering, leadership, and startups.',
+  description: siteConfig.description,
+  alternates: {
+    types: feedAlternates,
+  },
   icons: {
     icon: [{ url: '/icon' }],
     apple: [{ url: '/apple-icon' }],
   },
   openGraph: {
-    title: 'addcommitpush.io - Emil Wåreus',
-    description:
-      'Tech blog by Emil Wåreus. Head of Engineering and Research. Writing about machine learning, data engineering, leadership, and startups.',
-    siteName: 'addcommitpush.io',
+    title: siteConfig.title,
+    description: siteConfig.description,
+    siteName: siteConfig.name,
     type: 'website',
   },
   twitter: {
     card: 'summary',
-    title: 'addcommitpush.io - Emil Wåreus',
-    description:
-      'Tech blog by Emil Wåreus. Head of Engineering and Research. Writing about machine learning, data engineering, leadership, and startups.',
+    title: siteConfig.title,
+    description: siteConfig.description,
   },
 };
 

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,6 +1,8 @@
 import { BlogCard } from '@/components/blog-card';
 import { BlogTerminalHero } from '@/components/blog-terminal-hero';
 import { getAllPosts } from '@/lib/posts';
+import { feedAlternates, siteConfig } from '@/lib/site';
+import { Rss } from 'lucide-react';
 
 // Fully static: error if dynamic APIs are used
 export const dynamic = 'error';
@@ -24,13 +26,14 @@ export const metadata = {
   creator: 'Emil Wåreus',
   publisher: 'Emil Wåreus',
   alternates: {
-    canonical: 'https://addcommitpush.io',
+    canonical: siteConfig.url,
+    types: feedAlternates,
   },
   openGraph: {
     type: 'website',
     locale: 'en_US',
-    url: 'https://addcommitpush.io',
-    siteName: 'addcommitpush.io',
+    url: siteConfig.url,
+    siteName: siteConfig.name,
     title: 'addcommitpush.io | Tech, Data, Leadership & Startups',
     description:
       "Emil Wåreus' blog on tech, data, leadership, and startups. Software engineer, founder, researcher, and investor sharing insights on building products, scaling teams, and navigating the startup ecosystem.",
@@ -70,6 +73,21 @@ export default function HomePage() {
           Notes on tech, data, leadership & startups by Emil Wåreus: coder, founder, researcher,
           investor. Every post ships with audio narration.
         </p>
+        <div className="mt-5 flex flex-wrap items-center gap-3 text-[11px] font-medium uppercase tracking-[0.08em]">
+          <a
+            href={siteConfig.feeds.rss}
+            className="inline-flex items-center gap-2 text-muted-foreground no-underline transition-colors hover:text-primary"
+          >
+            <Rss className="h-3.5 w-3.5" aria-hidden="true" />
+            RSS
+          </a>
+          <a
+            href={siteConfig.feeds.atom}
+            className="text-muted-foreground no-underline transition-colors hover:text-primary"
+          >
+            Atom
+          </a>
+        </div>
       </section>
 
       <section className="grid gap-6 pb-14 md:grid-cols-2">

--- a/app/robots.ts
+++ b/app/robots.ts
@@ -1,0 +1,13 @@
+import type { MetadataRoute } from 'next';
+import { siteConfig } from '@/lib/site';
+
+export default function robots(): MetadataRoute.Robots {
+  return {
+    rules: {
+      userAgent: '*',
+      allow: '/',
+    },
+    sitemap: new URL('/sitemap.xml', siteConfig.url).toString(),
+    host: siteConfig.url,
+  };
+}

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -1,0 +1,63 @@
+import type { MetadataRoute } from 'next';
+import { getAllPosts, type Post } from '@/lib/posts';
+import { siteConfig } from '@/lib/site';
+
+function absoluteUrl(pathname: string): string {
+  return new URL(pathname, siteConfig.url).toString();
+}
+
+function parseDate(value: string): Date {
+  return new Date(value.includes('T') ? value : `${value}T00:00:00.000Z`);
+}
+
+function getPostLastModified(post: Post): Date {
+  if (post.updatedAt) {
+    return parseDate(post.updatedAt);
+  }
+
+  return parseDate(post.publishedAt);
+}
+
+export default function sitemap(): MetadataRoute.Sitemap {
+  const staticRoutes: MetadataRoute.Sitemap = [
+    {
+      url: absoluteUrl('/'),
+      lastModified: new Date('2026-07-07T00:00:00.000Z'),
+      changeFrequency: 'weekly',
+      priority: 1,
+    },
+    {
+      url: absoluteUrl('/brain'),
+      lastModified: new Date('2026-07-07T00:00:00.000Z'),
+      changeFrequency: 'weekly',
+      priority: 0.6,
+    },
+    {
+      url: absoluteUrl('/presentations'),
+      lastModified: new Date('2026-07-07T00:00:00.000Z'),
+      changeFrequency: 'monthly',
+      priority: 0.5,
+    },
+    {
+      url: absoluteUrl('/about'),
+      lastModified: new Date('2026-07-07T00:00:00.000Z'),
+      changeFrequency: 'monthly',
+      priority: 0.5,
+    },
+    {
+      url: absoluteUrl('/status'),
+      lastModified: new Date('2026-07-07T00:00:00.000Z'),
+      changeFrequency: 'daily',
+      priority: 0.3,
+    },
+  ];
+
+  const postRoutes = getAllPosts().map((post) => ({
+    url: absoluteUrl(`/blog/${post.slug}`),
+    lastModified: getPostLastModified(post),
+    changeFrequency: 'monthly' as const,
+    priority: 0.8,
+  }));
+
+  return [...staticRoutes, ...postRoutes];
+}

--- a/lib/posts.ts
+++ b/lib/posts.ts
@@ -8,6 +8,9 @@ export interface Post {
   cover?: string;
   readTime: string;
   audioUrl?: string;
+  draft?: boolean;
+  canonicalUrl?: string;
+  ogImage?: string;
 }
 
 const posts: Post[] = [
@@ -65,15 +68,17 @@ const posts: Post[] = [
 ];
 
 export function getAllPosts(): Post[] {
-  return posts.sort((a, b) => {
-    return new Date(b.publishedAt).getTime() - new Date(a.publishedAt).getTime();
-  });
+  return posts
+    .filter((post) => post.draft !== true)
+    .sort((a, b) => {
+      return new Date(b.publishedAt).getTime() - new Date(a.publishedAt).getTime();
+    });
 }
 
 export function getPostBySlug(slug: string): Post | null {
-  return posts.find((post) => post.slug === slug) || null;
+  return posts.find((post) => post.slug === slug && post.draft !== true) || null;
 }
 
 export function getAllSlugs(): string[] {
-  return posts.map((post) => post.slug);
+  return getAllPosts().map((post) => post.slug);
 }

--- a/lib/site.ts
+++ b/lib/site.ts
@@ -1,0 +1,35 @@
+import type { Metadata } from 'next';
+
+type MetadataAlternates = NonNullable<Metadata['alternates']>;
+type FeedAlternates = NonNullable<MetadataAlternates['types']>;
+
+export const siteConfig = {
+  name: 'addcommitpush.io',
+  title: 'addcommitpush.io - Emil Wåreus',
+  description:
+    'Tech blog by Emil Wåreus. Head of Engineering and Research. Writing about machine learning, data engineering, leadership, and startups.',
+  url: 'https://addcommitpush.io',
+  author: {
+    name: 'Emil Wåreus',
+    email: 'emil@addcommitpush.io',
+  },
+  feeds: {
+    rss: '/feed.xml',
+    atom: '/feed.atom',
+  },
+} as const;
+
+export const feedAlternates: FeedAlternates = {
+  'application/rss+xml': [
+    {
+      title: `${siteConfig.name} RSS Feed`,
+      url: siteConfig.feeds.rss,
+    },
+  ],
+  'application/atom+xml': [
+    {
+      title: `${siteConfig.name} Atom Feed`,
+      url: siteConfig.feeds.atom,
+    },
+  ],
+};

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "packageManager": "pnpm@10.33.2",
   "scripts": {
     "dev": "next dev --port 49237",
-    "build": "next build",
+    "build": "pnpm generate-feeds && next build",
     "start": "next start",
     "lint": "eslint .",
     "typecheck": "tsc --noEmit",
@@ -14,6 +14,7 @@
     "check": "pnpm format && pnpm lint && pnpm build",
     "check-links": "tsx scripts/check-about-links.ts",
     "optimize-images": "tsx scripts/optimize-images.ts",
+    "generate-feeds": "tsx scripts/generate-feeds.ts",
     "extract-text": "tsx scripts/extract-post-text.ts",
     "generate-audio": "tsx scripts/generate-audio.ts"
   },

--- a/public/feed.atom
+++ b/public/feed.atom
@@ -1,0 +1,72 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom">
+  <title>addcommitpush.io - Emil Wåreus</title>
+  <subtitle>Tech blog by Emil Wåreus. Head of Engineering and Research. Writing about machine learning, data engineering, leadership, and startups.</subtitle>
+  <id>https://addcommitpush.io</id>
+  <link rel="alternate" href="https://addcommitpush.io" />
+  <link rel="self" href="https://addcommitpush.io/feed.atom" type="application/atom+xml" />
+  <updated>2026-06-09T00:00:00.000Z</updated>
+  <author>
+    <name>Emil Wåreus</name>
+    <email>emil@addcommitpush.io</email>
+  </author>
+  <entry>
+    <title>Write Code That AI Agents Love</title>
+    <id>https://addcommitpush.io/blog/write-code-that-ai-agents-love</id>
+    <link rel="alternate" href="https://addcommitpush.io/blog/write-code-that-ai-agents-love" />
+    <published>2026-06-09T00:00:00.000Z</published>
+    <updated>2026-06-09T00:00:00.000Z</updated>
+    <summary type="html">A technical talk on making codebases easier for AI agents and humans to work in.</summary>
+    <category term="ai" />
+    <category term="agents" />
+    <category term="software" />
+  </entry>
+  <entry>
+    <title>Diffusion Deep Research</title>
+    <id>https://addcommitpush.io/blog/diffusion-deep-research</id>
+    <link rel="alternate" href="https://addcommitpush.io/blog/diffusion-deep-research" />
+    <published>2025-12-05T00:00:00.000Z</published>
+    <updated>2025-12-05T00:00:00.000Z</updated>
+    <summary type="html">How diffusion can be used to create a deep research report.</summary>
+    <category term="ai" />
+    <category term="agents" />
+    <category term="research" />
+    <category term="deep-research" />
+  </entry>
+  <entry>
+    <title>Advanced Context Engineering with Claude Code</title>
+    <id>https://addcommitpush.io/blog/context-engineering-claude-code</id>
+    <link rel="alternate" href="https://addcommitpush.io/blog/context-engineering-claude-code" />
+    <published>2025-11-07T00:00:00.000Z</published>
+    <updated>2025-11-07T00:00:00.000Z</updated>
+    <summary type="html">How to structure, compact, and orchestrate information with commands, agents, and scripts.</summary>
+    <category term="ai" />
+    <category term="agents" />
+    <category term="workflows" />
+    <category term="research" />
+    <link rel="enclosure" href="https://addcommitpush.io/posts/context-engineering-claude-code/audio.mp3" type="audio/mpeg" length="21463292" />
+  </entry>
+  <entry>
+    <title>Recruiting engineers as a startup</title>
+    <id>https://addcommitpush.io/blog/recruiting-engineers-as-a-startup</id>
+    <link rel="alternate" href="https://addcommitpush.io/blog/recruiting-engineers-as-a-startup" />
+    <published>2023-03-25T00:00:00.000Z</published>
+    <updated>2023-03-25T00:00:00.000Z</updated>
+    <summary type="html">As someone who&apos;s worked as a data lead or head of engineering for the past years, I&apos;ve learned a lot about finding and hiring great engineers.</summary>
+    <category term="startup" />
+    <category term="leadership" />
+    <category term="software" />
+    <link rel="enclosure" href="https://addcommitpush.io/posts/recruiting-engineers-as-a-startup/audio.mp3" type="audio/mpeg" length="16960617" />
+  </entry>
+  <entry>
+    <title>Building a SaaS Business, Zero to One in Hindsight</title>
+    <id>https://addcommitpush.io/blog/saas-zero-to-one-hindsight</id>
+    <link rel="alternate" href="https://addcommitpush.io/blog/saas-zero-to-one-hindsight" />
+    <published>2022-12-27T00:00:00.000Z</published>
+    <updated>2022-12-27T00:00:00.000Z</updated>
+    <summary type="html">Lessons learned from building Debricked as a co-founder, covering customer validation, execution prioritization, data-driven culture, conviction-based building, and focus strategies.</summary>
+    <category term="startup" />
+    <category term="saas" />
+    <category term="business" />
+  </entry>
+</feed>

--- a/public/feed.xml
+++ b/public/feed.xml
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
+  <channel>
+    <title>addcommitpush.io - Emil Wåreus</title>
+    <link>https://addcommitpush.io</link>
+    <atom:link href="https://addcommitpush.io/feed.xml" rel="self" type="application/rss+xml" />
+    <description>Tech blog by Emil Wåreus. Head of Engineering and Research. Writing about machine learning, data engineering, leadership, and startups.</description>
+    <language>en</language>
+    <lastBuildDate>Tue, 09 Jun 2026 00:00:00 GMT</lastBuildDate>
+    <generator>addcommitpush.io feed generator</generator>
+    <item>
+      <title>Write Code That AI Agents Love</title>
+      <link>https://addcommitpush.io/blog/write-code-that-ai-agents-love</link>
+      <guid isPermaLink="true">https://addcommitpush.io/blog/write-code-that-ai-agents-love</guid>
+      <pubDate>Tue, 09 Jun 2026 00:00:00 GMT</pubDate>
+      <description><![CDATA[A technical talk on making codebases easier for AI agents and humans to work in.]]></description>
+      <category>ai</category>
+      <category>agents</category>
+      <category>software</category>
+    </item>
+    <item>
+      <title>Diffusion Deep Research</title>
+      <link>https://addcommitpush.io/blog/diffusion-deep-research</link>
+      <guid isPermaLink="true">https://addcommitpush.io/blog/diffusion-deep-research</guid>
+      <pubDate>Fri, 05 Dec 2025 00:00:00 GMT</pubDate>
+      <description><![CDATA[How diffusion can be used to create a deep research report.]]></description>
+      <category>ai</category>
+      <category>agents</category>
+      <category>research</category>
+      <category>deep-research</category>
+    </item>
+    <item>
+      <title>Advanced Context Engineering with Claude Code</title>
+      <link>https://addcommitpush.io/blog/context-engineering-claude-code</link>
+      <guid isPermaLink="true">https://addcommitpush.io/blog/context-engineering-claude-code</guid>
+      <pubDate>Fri, 07 Nov 2025 00:00:00 GMT</pubDate>
+      <description><![CDATA[How to structure, compact, and orchestrate information with commands, agents, and scripts.]]></description>
+      <category>ai</category>
+      <category>agents</category>
+      <category>workflows</category>
+      <category>research</category>
+      <enclosure url="https://addcommitpush.io/posts/context-engineering-claude-code/audio.mp3" length="21463292" type="audio/mpeg" />
+    </item>
+    <item>
+      <title>Recruiting engineers as a startup</title>
+      <link>https://addcommitpush.io/blog/recruiting-engineers-as-a-startup</link>
+      <guid isPermaLink="true">https://addcommitpush.io/blog/recruiting-engineers-as-a-startup</guid>
+      <pubDate>Sat, 25 Mar 2023 00:00:00 GMT</pubDate>
+      <description><![CDATA[As someone who's worked as a data lead or head of engineering for the past years, I've learned a lot about finding and hiring great engineers.]]></description>
+      <category>startup</category>
+      <category>leadership</category>
+      <category>software</category>
+      <enclosure url="https://addcommitpush.io/posts/recruiting-engineers-as-a-startup/audio.mp3" length="16960617" type="audio/mpeg" />
+    </item>
+    <item>
+      <title>Building a SaaS Business, Zero to One in Hindsight</title>
+      <link>https://addcommitpush.io/blog/saas-zero-to-one-hindsight</link>
+      <guid isPermaLink="true">https://addcommitpush.io/blog/saas-zero-to-one-hindsight</guid>
+      <pubDate>Tue, 27 Dec 2022 00:00:00 GMT</pubDate>
+      <description><![CDATA[Lessons learned from building Debricked as a co-founder, covering customer validation, execution prioritization, data-driven culture, conviction-based building, and focus strategies.]]></description>
+      <category>startup</category>
+      <category>saas</category>
+      <category>business</category>
+    </item>
+  </channel>
+</rss>

--- a/scripts/generate-feeds.ts
+++ b/scripts/generate-feeds.ts
@@ -1,0 +1,187 @@
+#!/usr/bin/env tsx
+
+import { mkdir, stat, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+import { getAllPosts, type Post } from '../lib/posts';
+import { siteConfig } from '../lib/site';
+
+interface AudioEnclosure {
+  url: string;
+  length: number;
+  type: 'audio/mpeg';
+}
+
+interface FeedEntry {
+  title: string;
+  slug: string;
+  description: string;
+  url: string;
+  publishedAt: Date;
+  updatedAt: Date;
+  tags: string[];
+  audioEnclosure?: AudioEnclosure;
+}
+
+const outputDirectory = path.join(process.cwd(), 'public');
+
+function absoluteUrl(pathname: string): string {
+  return new URL(pathname, siteConfig.url).toString();
+}
+
+function parsePostDate(value: string): Date {
+  const date = new Date(value.includes('T') ? value : `${value}T00:00:00.000Z`);
+
+  if (Number.isNaN(date.getTime())) {
+    throw new Error(`Invalid post date: ${value}`);
+  }
+
+  return date;
+}
+
+function getPostUpdatedAt(post: Post): Date {
+  if (post.updatedAt) {
+    return parsePostDate(post.updatedAt);
+  }
+
+  return parsePostDate(post.publishedAt);
+}
+
+function escapeXml(value: string): string {
+  return value
+    .replaceAll('&', '&amp;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;')
+    .replaceAll('"', '&quot;')
+    .replaceAll("'", '&apos;');
+}
+
+function cdata(value: string): string {
+  return `<![CDATA[${value.replaceAll(']]>', ']]]]><![CDATA[>')}]]>`;
+}
+
+async function getAudioEnclosure(post: Post): Promise<AudioEnclosure | undefined> {
+  if (!post.audioUrl) {
+    return undefined;
+  }
+
+  const filePath = path.join(outputDirectory, post.audioUrl.replace(/^\//, ''));
+  const fileStats = await stat(filePath);
+
+  return {
+    url: absoluteUrl(post.audioUrl),
+    length: fileStats.size,
+    type: 'audio/mpeg',
+  };
+}
+
+async function getFeedEntries(): Promise<FeedEntry[]> {
+  const posts = getAllPosts();
+
+  return Promise.all(
+    posts.map(async (post) => ({
+      title: post.title,
+      slug: post.slug,
+      description: post.description,
+      url: absoluteUrl(`/blog/${post.slug}`),
+      publishedAt: parsePostDate(post.publishedAt),
+      updatedAt: getPostUpdatedAt(post),
+      tags: post.tags ?? [],
+      audioEnclosure: await getAudioEnclosure(post),
+    }))
+  );
+}
+
+function getLatestUpdatedAt(entries: FeedEntry[]): Date {
+  return new Date(Math.max(...entries.map((entry) => entry.updatedAt.getTime())));
+}
+
+function renderRssItem(entry: FeedEntry): string {
+  const categories = entry.tags
+    .map((tag) => `      <category>${escapeXml(tag)}</category>`)
+    .join('\n');
+  const enclosure = entry.audioEnclosure
+    ? `\n      <enclosure url="${escapeXml(entry.audioEnclosure.url)}" length="${entry.audioEnclosure.length}" type="${entry.audioEnclosure.type}" />`
+    : '';
+
+  return `    <item>
+      <title>${escapeXml(entry.title)}</title>
+      <link>${escapeXml(entry.url)}</link>
+      <guid isPermaLink="true">${escapeXml(entry.url)}</guid>
+      <pubDate>${entry.publishedAt.toUTCString()}</pubDate>
+      <description>${cdata(entry.description)}</description>${categories ? `\n${categories}` : ''}${enclosure}
+    </item>`;
+}
+
+function renderRss(entries: FeedEntry[]): string {
+  const lastUpdatedAt = getLatestUpdatedAt(entries);
+  const items = entries.map(renderRssItem).join('\n');
+
+  return `<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
+  <channel>
+    <title>${escapeXml(siteConfig.title)}</title>
+    <link>${escapeXml(siteConfig.url)}</link>
+    <atom:link href="${escapeXml(absoluteUrl(siteConfig.feeds.rss))}" rel="self" type="application/rss+xml" />
+    <description>${escapeXml(siteConfig.description)}</description>
+    <language>en</language>
+    <lastBuildDate>${lastUpdatedAt.toUTCString()}</lastBuildDate>
+    <generator>addcommitpush.io feed generator</generator>
+${items}
+  </channel>
+</rss>
+`;
+}
+
+function renderAtomEntry(entry: FeedEntry): string {
+  const categories = entry.tags
+    .map((tag) => `    <category term="${escapeXml(tag)}" />`)
+    .join('\n');
+  const enclosure = entry.audioEnclosure
+    ? `\n    <link rel="enclosure" href="${escapeXml(entry.audioEnclosure.url)}" type="${entry.audioEnclosure.type}" length="${entry.audioEnclosure.length}" />`
+    : '';
+
+  return `  <entry>
+    <title>${escapeXml(entry.title)}</title>
+    <id>${escapeXml(entry.url)}</id>
+    <link rel="alternate" href="${escapeXml(entry.url)}" />
+    <published>${entry.publishedAt.toISOString()}</published>
+    <updated>${entry.updatedAt.toISOString()}</updated>
+    <summary type="html">${escapeXml(entry.description)}</summary>${categories ? `\n${categories}` : ''}${enclosure}
+  </entry>`;
+}
+
+function renderAtom(entries: FeedEntry[]): string {
+  const lastUpdatedAt = getLatestUpdatedAt(entries);
+  const atomEntries = entries.map(renderAtomEntry).join('\n');
+
+  return `<?xml version="1.0" encoding="UTF-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom">
+  <title>${escapeXml(siteConfig.title)}</title>
+  <subtitle>${escapeXml(siteConfig.description)}</subtitle>
+  <id>${escapeXml(siteConfig.url)}</id>
+  <link rel="alternate" href="${escapeXml(siteConfig.url)}" />
+  <link rel="self" href="${escapeXml(absoluteUrl(siteConfig.feeds.atom))}" type="application/atom+xml" />
+  <updated>${lastUpdatedAt.toISOString()}</updated>
+  <author>
+    <name>${escapeXml(siteConfig.author.name)}</name>
+    <email>${escapeXml(siteConfig.author.email)}</email>
+  </author>
+${atomEntries}
+</feed>
+`;
+}
+
+async function main() {
+  const entries = await getFeedEntries();
+
+  await mkdir(outputDirectory, { recursive: true });
+  await writeFile(path.join(outputDirectory, 'feed.xml'), renderRss(entries));
+  await writeFile(path.join(outputDirectory, 'feed.atom'), renderAtom(entries));
+
+  console.log(`Generated ${entries.length} posts in public/feed.xml and public/feed.atom`);
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});


### PR DESCRIPTION
Adds committed RSS 2.0 and Atom feed files generated from the blog post registry, including audio enclosures for posts with narration. Adds a build-time feed generator, shared site metadata, feed autodiscovery, visible subscribe links, and sitemap/robots routes. Draft posts are excluded from feeds and static blog params. Validated with typecheck, lint, targeted Prettier check, production build, XML parsing, and whitespace diff check.